### PR TITLE
chore: PR이 특정 브랜치에 병합될 때 issue가 자동으로 닫히게 하는 github actions 설정

### DIFF
--- a/.github/workflows/close-issues-on-pr-merge.yml
+++ b/.github/workflows/close-issues-on-pr-merge.yml
@@ -1,0 +1,28 @@
+name: Auto-close linked issues on PR merge
+
+on:
+  pull_request:
+    types:
+      - closed # PR이 머지되거나 닫힐 때 실행
+
+jobs:
+  close-linked-issues:
+    if: >
+      github.event.pull_request.merged == true &&
+      (
+        github.event.pull_request.base.ref == 'main' ||
+        github.event.pull_request.base.ref == 'dev' ||
+        github.event.pull_request.base.ref == 'dev-be' ||
+        github.event.pull_request.base.ref == 'dev-fe'
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+
+    steps:
+      - name: Close linked issues
+        uses: peter-evans/close-issue@v3
+        with:
+          comment: |
+            이 PR이 `{{ base.ref }}` 브랜치로 머지되어 관련 이슈를 자동으로 닫습니다. ✅


### PR DESCRIPTION
## 📝 기능 설명
PR이 main / dev / dev-fe / dev-be 브랜치에 병합될 때 연관 issue가 자동으로 닫히게끔 github actions를 설정했습니다.

## 🛠 작업 사항
PR 병합 시 자동으로 연결된 이슈를 닫는 워크플로우를 작성했습니다.

## ✅ 작업 항목
- [x] GitHub Actions .yml 파일 생성
- [x] main, dev, dev-fe, dev-be 브랜치에 대한 조건 설정

## 📎 참고 자료
지수님께서 알려주신 코드