### PR TITLE
[ Feat/#20 ] page routing 구현

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "prettier": "^3.6.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-router": "^7.7.1",
     "vite-plugin-svgr": "^4.3.0"
   },
   "devDependencies": {

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
+      react-router:
+        specifier: ^7.7.1
+        version: 7.7.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       vite-plugin-svgr:
         specifier: ^4.3.0
         version: 4.3.0(rollup@4.46.1)(typescript@5.8.3)(vite@7.0.6(@types/node@24.1.0)(tsx@4.20.3))
@@ -732,6 +735,10 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie@1.0.2:
+    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
+    engines: {node: '>=18'}
+
   cosmiconfig@8.3.6:
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
     engines: {node: '>=14'}
@@ -1116,6 +1123,16 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
+  react-router@7.7.1:
+    resolution: {integrity: sha512-jVKHXoWRIsD/qS6lvGveckwb862EekvapdHJN/cGmzw40KnJH5gg53ujOJ4qX6EKIK9LSBfFed/xiQ5yeXNrUA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react@19.1.0:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
     engines: {node: '>=0.10.0'}
@@ -1150,6 +1167,9 @@ packages:
     resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  set-cookie-parser@2.7.1:
+    resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1913,6 +1933,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie@1.0.2: {}
+
   cosmiconfig@8.3.6(typescript@5.8.3):
     dependencies:
       import-fresh: 3.3.1
@@ -2286,6 +2308,14 @@ snapshots:
 
   react-refresh@0.17.0: {}
 
+  react-router@7.7.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      cookie: 1.0.2
+      react: 19.1.0
+      set-cookie-parser: 2.7.1
+    optionalDependencies:
+      react-dom: 19.1.0(react@19.1.0)
+
   react@19.1.0: {}
 
   resolve-from@4.0.0: {}
@@ -2330,6 +2360,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.2: {}
+
+  set-cookie-parser@2.7.1: {}
 
   shebang-command@2.0.0:
     dependencies:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
+import Router from "@/routes";
 import "@/styles/global.style.css";
 function App() {
-  return <></>;
+  return <Router />;
 }
 
 export default App;

--- a/frontend/src/pages/admin/drivers.tsx
+++ b/frontend/src/pages/admin/drivers.tsx
@@ -1,0 +1,5 @@
+const Drivers = () => {
+  return <></>;
+};
+
+export default Drivers;

--- a/frontend/src/pages/admin/index.tsx
+++ b/frontend/src/pages/admin/index.tsx
@@ -1,0 +1,5 @@
+const Admin = () => {
+  return <></>;
+};
+
+export default Admin;

--- a/frontend/src/pages/admin/register.tsx
+++ b/frontend/src/pages/admin/register.tsx
@@ -1,0 +1,5 @@
+const AdminRegister = () => {
+  return <></>;
+};
+
+export default AdminRegister;

--- a/frontend/src/pages/admin/reservation/index.tsx
+++ b/frontend/src/pages/admin/reservation/index.tsx
@@ -1,0 +1,5 @@
+const Reservation = () => {
+  return <></>;
+};
+
+export default Reservation;

--- a/frontend/src/pages/admin/reservation/paths.tsx
+++ b/frontend/src/pages/admin/reservation/paths.tsx
@@ -1,0 +1,5 @@
+const Paths = () => {
+  return <></>;
+};
+
+export default Paths;

--- a/frontend/src/pages/admin/reservation/schedule.tsx
+++ b/frontend/src/pages/admin/reservation/schedule.tsx
@@ -1,0 +1,5 @@
+const Schedule = () => {
+  return <></>;
+};
+
+export default Schedule;

--- a/frontend/src/pages/admin/reservation/users.tsx
+++ b/frontend/src/pages/admin/reservation/users.tsx
@@ -1,0 +1,5 @@
+const Users = () => {
+  return <></>;
+};
+
+export default Users;

--- a/frontend/src/pages/admin/vehicles/[centerId].tsx
+++ b/frontend/src/pages/admin/vehicles/[centerId].tsx
@@ -1,0 +1,5 @@
+const CenterDetail = () => {
+  return <>centerDetail</>;
+};
+
+export default CenterDetail;

--- a/frontend/src/pages/admin/vehicles/index.tsx
+++ b/frontend/src/pages/admin/vehicles/index.tsx
@@ -1,0 +1,5 @@
+const Vehicles = () => {
+  return <></>;
+};
+
+export default Vehicles;

--- a/frontend/src/pages/center/index.tsx
+++ b/frontend/src/pages/center/index.tsx
@@ -1,0 +1,5 @@
+const Center = () => {
+  return <></>;
+};
+
+export default Center;

--- a/frontend/src/pages/center/register.tsx
+++ b/frontend/src/pages/center/register.tsx
@@ -1,0 +1,5 @@
+const VehicleRegister = () => {
+  return <></>;
+};
+
+export default VehicleRegister;

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,0 +1,5 @@
+const Landing = () => {
+  return <></>;
+};
+
+export default Landing;

--- a/frontend/src/pages/notFound.tsx
+++ b/frontend/src/pages/notFound.tsx
@@ -1,0 +1,5 @@
+const NotFound = () => {
+  return <>Not Found</>;
+};
+
+export default NotFound;

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,0 +1,40 @@
+import { BrowserRouter, Route, Routes } from "react-router";
+
+const Router = () => {
+  return (
+    <BrowserRouter>
+      <Routes>
+        {/* Admin 영역 */}
+        <Route path="/admin">
+          <Route index element={<>admin</>} />
+          <Route path="reservation">
+            <Route index element={<>reservation</>} />
+            <Route path="schedule" element={<>schedule</>} />
+            <Route path="users" element={<>users</>} />
+            <Route path="paths" element={<>paths</>} />
+          </Route>
+          <Route path="vehicles">
+            <Route index element={<>vehicles</>} />
+            <Route path=":id" element={<>id</>} />
+          </Route>
+          <Route path="drivers" element={<>drivers</>} />
+          <Route path="register" element={<>register</>} />
+        </Route>
+
+        {/* Center 영역 */}
+        <Route path="/center">
+          <Route index element={<>center</>} />
+          <Route path="register" element={<>register</>} />
+        </Route>
+
+        {/* 초기 진입 시 리디렉션 */}
+        <Route path="/" element={<>first</>} />
+
+        {/* Not found */}
+        <Route path="/*" element={<>Not found</>} />
+      </Routes>
+    </BrowserRouter>
+  );
+};
+
+export default Router;

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,3 +1,16 @@
+import Landing from "@/pages";
+import Admin from "@/pages/admin";
+import Drivers from "@/pages/admin/drivers";
+import AdminRegister from "@/pages/admin/register";
+import Reservation from "@/pages/admin/reservation";
+import Paths from "@/pages/admin/reservation/paths";
+import Schedule from "@/pages/admin/reservation/schedule";
+import Users from "@/pages/admin/reservation/users";
+import Vehicles from "@/pages/admin/vehicles";
+import CenterDetail from "@/pages/admin/vehicles/[centerId]";
+import Center from "@/pages/center";
+import VehicleRegister from "@/pages/center/register";
+import NotFound from "@/pages/notFound";
 import { BrowserRouter, Route, Routes } from "react-router";
 
 const Router = () => {
@@ -6,32 +19,32 @@ const Router = () => {
       <Routes>
         {/* Admin 영역 */}
         <Route path="/admin">
-          <Route index element={<>admin</>} />
+          <Route index element={<Admin />} />
           <Route path="reservation">
-            <Route index element={<>reservation</>} />
-            <Route path="schedule" element={<>schedule</>} />
-            <Route path="users" element={<>users</>} />
-            <Route path="paths" element={<>paths</>} />
+            <Route index element={<Reservation />} />
+            <Route path="schedule" element={<Schedule />} />
+            <Route path="users" element={<Users />} />
+            <Route path="paths" element={<Paths />} />
           </Route>
           <Route path="vehicles">
-            <Route index element={<>vehicles</>} />
-            <Route path=":id" element={<>id</>} />
+            <Route index element={<Vehicles />} />
+            <Route path=":id" element={<CenterDetail />} />
           </Route>
-          <Route path="drivers" element={<>drivers</>} />
-          <Route path="register" element={<>register</>} />
+          <Route path="drivers" element={<Drivers />} />
+          <Route path="register" element={<AdminRegister />} />
         </Route>
 
         {/* Center 영역 */}
         <Route path="/center">
-          <Route index element={<>center</>} />
-          <Route path="register" element={<>register</>} />
+          <Route index element={<Center />} />
+          <Route path="register" element={<VehicleRegister />} />
         </Route>
 
         {/* 초기 진입 시 리디렉션 */}
-        <Route path="/" element={<>first</>} />
+        <Route path="/" element={<Landing />} />
 
         {/* Not found */}
-        <Route path="/*" element={<>Not found</>} />
+        <Route path="/*" element={<NotFound />} />
       </Routes>
     </BrowserRouter>
   );


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Close #20 

## 📝 기능 설명
page routing을 구현했습니다.

## 🛠 작업 사항
- 화면을 기준으로 페이지를 분할하고, 구조를 설계한 후 라우터를 구현했습니다.
```
/
├── Landing Page                  (/)
├── Not Found                    (/*)

├── admin                        (/admin)
│   ├── 대시보드 (기본)         (/admin)
│   ├── 예약 운행 관리          (/admin/reservation)
│   │   ├── 예약 현황 (기본)   (/admin/reservation)
│   │   ├── 실시간 운행 현황   (/admin/reservation/schedule)
│   │   ├── 예약자 관리        (/admin/reservation/users)
│   │   └── 운행 경로 관리     (/admin/reservation/paths)
│   ├── 센터 차량 관리          (/admin/vehicles)
│   │   ├── 목록               (/admin/vehicles)
│   │   └── 센터 상세          (/admin/vehicles/:id)
│   ├── 운전기사 관리          (/admin/drivers)
│   └── 신규 예약 등록         (/admin/AdminRegister)

├── center                       (/center)
│   ├── 차량 목록 (기본)        (/center)
│   └── 차량 등록              (/center/VehicleRegister)
```

## ✅ 작업 항목

- [x] 진입점 분리(entry point)
- [x] 관리자 페이지 관련 라우팅 구현
- [x] 주간보호센터 페이지 관련 라우팅 구현
