### PR TITLE
[ Feat/#32 ] 페이지 라우팅 수정

### DIFF
--- a/frontend/src/pages/admin/drivers.tsx
+++ b/frontend/src/pages/admin/drivers.tsx
@@ -1,5 +1,5 @@
 const Drivers = () => {
-  return <></>;
+  return <>Drivers</>;
 };
 
 export default Drivers;

--- a/frontend/src/pages/admin/index.tsx
+++ b/frontend/src/pages/admin/index.tsx
@@ -1,5 +1,5 @@
 const Admin = () => {
-  return <></>;
+  return <>Admin</>;
 };
 
 export default Admin;

--- a/frontend/src/pages/admin/register.tsx
+++ b/frontend/src/pages/admin/register.tsx
@@ -1,5 +1,5 @@
 const AdminRegister = () => {
-  return <></>;
+  return <>AdminRegister</>;
 };
 
 export default AdminRegister;

--- a/frontend/src/pages/admin/reservation/index.tsx
+++ b/frontend/src/pages/admin/reservation/index.tsx
@@ -1,5 +1,5 @@
 const Reservation = () => {
-  return <></>;
+  return <>Reservation</>;
 };
 
 export default Reservation;

--- a/frontend/src/pages/admin/reservation/paths.tsx
+++ b/frontend/src/pages/admin/reservation/paths.tsx
@@ -1,5 +1,5 @@
 const Paths = () => {
-  return <></>;
+  return <>Paths</>;
 };
 
 export default Paths;

--- a/frontend/src/pages/admin/reservation/schedule.tsx
+++ b/frontend/src/pages/admin/reservation/schedule.tsx
@@ -1,5 +1,5 @@
 const Schedule = () => {
-  return <></>;
+  return <>Schedule</>;
 };
 
 export default Schedule;

--- a/frontend/src/pages/admin/reservation/users.tsx
+++ b/frontend/src/pages/admin/reservation/users.tsx
@@ -1,5 +1,5 @@
 const Users = () => {
-  return <></>;
+  return <>Users</>;
 };
 
 export default Users;

--- a/frontend/src/pages/admin/vehicles/[centerId].tsx
+++ b/frontend/src/pages/admin/vehicles/[centerId].tsx
@@ -1,5 +1,5 @@
 const CenterDetail = () => {
-  return <>centerDetail</>;
+  return <>CenterDetail</>;
 };
 
 export default CenterDetail;

--- a/frontend/src/pages/admin/vehicles/index.tsx
+++ b/frontend/src/pages/admin/vehicles/index.tsx
@@ -1,5 +1,5 @@
 const Vehicles = () => {
-  return <></>;
+  return <>Vehicles</>;
 };
 
 export default Vehicles;

--- a/frontend/src/pages/center/index.tsx
+++ b/frontend/src/pages/center/index.tsx
@@ -1,5 +1,5 @@
 const Center = () => {
-  return <></>;
+  return <>Center</>;
 };
 
 export default Center;

--- a/frontend/src/pages/center/register.tsx
+++ b/frontend/src/pages/center/register.tsx
@@ -1,5 +1,5 @@
 const VehicleRegister = () => {
-  return <></>;
+  return <>VehicleRegister</>;
 };
 
 export default VehicleRegister;

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,5 +1,5 @@
 const Landing = () => {
-  return <></>;
+  return <>Landing</>;
 };
 
 export default Landing;

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -25,13 +25,13 @@ const Router = () => {
             <Route path="schedule" element={<Schedule />} />
             <Route path="users" element={<Users />} />
             <Route path="paths" element={<Paths />} />
+            <Route path="register" element={<AdminRegister />} />
           </Route>
           <Route path="vehicles">
             <Route index element={<Vehicles />} />
             <Route path=":id" element={<CenterDetail />} />
           </Route>
           <Route path="drivers" element={<Drivers />} />
-          <Route path="register" element={<AdminRegister />} />
         </Route>
 
         {/* Center 영역 */}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Close #32 

## 📝 기능 설명
수정된 기획에 따라 기존 구현한 페이지 라우팅 구조를 변경했습니다.


## 🛠 작업 사항
- 기존에는 admin의 register, reservation으로 depth를 동등하게 구분했으나, register이 reservation 내부에 위치해야 함을 파악하고 하위로 이동했습니다.
<img width="1116" height="359" alt="image" src="https://github.com/user-attachments/assets/abf20434-95c7-4e11-bf71-55685e1008de" />


## ✅ 작업 항목
- [x] 페이지 폴더 구조 수정(register page를 reservation page 하위에 배치)
- [x] 기본 컴포넌트로 초기화(기존 생성한 컴포넌트에 어떤 컴포넌트인지에 대한 간략한 문구 추가)

## 📎 참고 자료
<img width="978" height="585" alt="image" src="https://github.com/user-attachments/assets/28a85ac9-6fc6-4c3e-a404-86f53cfeefbd" />
