### PR TITLE
[ Feat/#19 ] 페이지별 레이아웃 분리 및 라우팅

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@emotion/react": "^11.14.0",
     "eslint-config-prettier": "^10.1.8",
     "prettier": "^3.6.2",
     "react": "^19.1.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@emotion/react':
+        specifier: ^11.14.0
+        version: 11.14.0(@types/react@19.1.8)(react@19.1.0)
       eslint-config-prettier:
         specifier: ^10.1.8
         version: 10.1.8(eslint@9.32.0)
@@ -144,6 +147,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/runtime@7.28.2':
+    resolution: {integrity: sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.27.2':
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
     engines: {node: '>=6.9.0'}
@@ -155,6 +162,47 @@ packages:
   '@babel/types@7.28.2':
     resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
     engines: {node: '>=6.9.0'}
+
+  '@emotion/babel-plugin@11.13.5':
+    resolution: {integrity: sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ==}
+
+  '@emotion/cache@11.14.0':
+    resolution: {integrity: sha512-L/B1lc/TViYk4DcpGxtAVbx0ZyiKM5ktoIyafGkH6zg/tj+mA+NE//aPYKG0k8kCHSHVJrpLpcAlOBEXQ3SavA==}
+
+  '@emotion/hash@0.9.2':
+    resolution: {integrity: sha512-MyqliTZGuOm3+5ZRSaaBGP3USLw6+EGykkwZns2EPC5g8jJ4z9OrdZY9apkl3+UP9+sdz76YYkwCKP5gh8iY3g==}
+
+  '@emotion/memoize@0.9.0':
+    resolution: {integrity: sha512-30FAj7/EoJ5mwVPOWhAyCX+FPfMDrVecJAM+Iw9NRoSl4BBAQeqj4cApHHUXOVvIPgLVDsCFoz/hGD+5QQD1GQ==}
+
+  '@emotion/react@11.14.0':
+    resolution: {integrity: sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@emotion/serialize@1.3.3':
+    resolution: {integrity: sha512-EISGqt7sSNWHGI76hC7x1CksiXPahbxEOrC5RjmFRJTqLyEK9/9hZvBbiYn70dw4wuwMKiEMCUlR6ZXTSWQqxA==}
+
+  '@emotion/sheet@1.4.0':
+    resolution: {integrity: sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==}
+
+  '@emotion/unitless@0.10.0':
+    resolution: {integrity: sha512-dFoMUuQA20zvtVTuxZww6OHoJYgrzfKM1t52mVySDJnMSEa08ruEvdYQbhvyu6soU+NeLVd3yKfTfT0NeV6qGg==}
+
+  '@emotion/use-insertion-effect-with-fallbacks@1.2.0':
+    resolution: {integrity: sha512-yJMtVdH59sxi/aVJBpk9FQq+OR8ll5GT8oWd57UpeaKEVGab41JWaCFA7FRLoMLloOZF/c/wsPoe+bfGmRKgDg==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@emotion/utils@1.4.2':
+    resolution: {integrity: sha512-3vLclRofFziIa3J2wDh9jjbkUz9qk5Vi3IZ/FSTKViB0k+ef0fPV7dYrUIugbgupYDx7v9ud/SjrtEP8Y4xLoA==}
+
+  '@emotion/weak-memoize@0.4.0':
+    resolution: {integrity: sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==}
 
   '@esbuild/aix-ppc64@0.25.8':
     resolution: {integrity: sha512-urAvrUedIqEiFR3FYSLTWQgLu5tb+m0qZw0NBEasUeo6wuqatkMDaRT+1uABiGXEu5vqgPd7FGE1BhsAIy9QVA==}
@@ -596,6 +644,9 @@ packages:
   '@types/node@24.1.0':
     resolution: {integrity: sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==}
 
+  '@types/parse-json@4.0.2':
+    resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
+
   '@types/react-dom@19.1.6':
     resolution: {integrity: sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==}
     peerDependencies:
@@ -689,6 +740,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  babel-plugin-macros@3.1.0:
+    resolution: {integrity: sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==}
+    engines: {node: '>=10', npm: '>=6'}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -732,12 +787,19 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  convert-source-map@1.9.0:
+    resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie@1.0.2:
     resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
     engines: {node: '>=18'}
+
+  cosmiconfig@7.1.0:
+    resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
+    engines: {node: '>=10'}
 
   cosmiconfig@8.3.6:
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
@@ -887,6 +949,9 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  find-root@1.1.0:
+    resolution: {integrity: sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -902,6 +967,9 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -933,6 +1001,13 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hoist-non-react-statics@3.3.2:
+    resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -951,6 +1026,10 @@ packages:
 
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-core-module@2.16.1:
+    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+    engines: {node: '>= 0.4'}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -1079,6 +1158,9 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
@@ -1119,6 +1201,9 @@ packages:
     peerDependencies:
       react: ^19.1.0
 
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
@@ -1143,6 +1228,11 @@ packages:
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  resolve@1.22.10:
+    resolution: {integrity: sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -1186,13 +1276,24 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.5.7:
+    resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
+    engines: {node: '>=0.10.0'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  stylis@4.2.0:
+    resolution: {integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
 
   svg-parser@2.0.4:
     resolution: {integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==}
@@ -1304,6 +1405,10 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  yaml@1.10.2:
+    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
+    engines: {node: '>= 6'}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -1404,6 +1509,8 @@ snapshots:
       '@babel/core': 7.28.0
       '@babel/helper-plugin-utils': 7.27.1
 
+  '@babel/runtime@7.28.2': {}
+
   '@babel/template@7.27.2':
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -1426,6 +1533,70 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
+
+  '@emotion/babel-plugin@11.13.5':
+    dependencies:
+      '@babel/helper-module-imports': 7.27.1
+      '@babel/runtime': 7.28.2
+      '@emotion/hash': 0.9.2
+      '@emotion/memoize': 0.9.0
+      '@emotion/serialize': 1.3.3
+      babel-plugin-macros: 3.1.0
+      convert-source-map: 1.9.0
+      escape-string-regexp: 4.0.0
+      find-root: 1.1.0
+      source-map: 0.5.7
+      stylis: 4.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@emotion/cache@11.14.0':
+    dependencies:
+      '@emotion/memoize': 0.9.0
+      '@emotion/sheet': 1.4.0
+      '@emotion/utils': 1.4.2
+      '@emotion/weak-memoize': 0.4.0
+      stylis: 4.2.0
+
+  '@emotion/hash@0.9.2': {}
+
+  '@emotion/memoize@0.9.0': {}
+
+  '@emotion/react@11.14.0(@types/react@19.1.8)(react@19.1.0)':
+    dependencies:
+      '@babel/runtime': 7.28.2
+      '@emotion/babel-plugin': 11.13.5
+      '@emotion/cache': 11.14.0
+      '@emotion/serialize': 1.3.3
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.1.0)
+      '@emotion/utils': 1.4.2
+      '@emotion/weak-memoize': 0.4.0
+      hoist-non-react-statics: 3.3.2
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.8
+    transitivePeerDependencies:
+      - supports-color
+
+  '@emotion/serialize@1.3.3':
+    dependencies:
+      '@emotion/hash': 0.9.2
+      '@emotion/memoize': 0.9.0
+      '@emotion/unitless': 0.10.0
+      '@emotion/utils': 1.4.2
+      csstype: 3.1.3
+
+  '@emotion/sheet@1.4.0': {}
+
+  '@emotion/unitless@0.10.0': {}
+
+  '@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+
+  '@emotion/utils@1.4.2': {}
+
+  '@emotion/weak-memoize@0.4.0': {}
 
   '@esbuild/aix-ppc64@0.25.8':
     optional: true
@@ -1758,6 +1929,8 @@ snapshots:
       undici-types: 7.8.0
     optional: true
 
+  '@types/parse-json@4.0.2': {}
+
   '@types/react-dom@19.1.6(@types/react@19.1.8)':
     dependencies:
       '@types/react': 19.1.8
@@ -1890,6 +2063,12 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  babel-plugin-macros@3.1.0:
+    dependencies:
+      '@babel/runtime': 7.28.2
+      cosmiconfig: 7.1.0
+      resolve: 1.22.10
+
   balanced-match@1.0.2: {}
 
   brace-expansion@1.1.12:
@@ -1931,9 +2110,19 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  convert-source-map@1.9.0: {}
+
   convert-source-map@2.0.0: {}
 
   cookie@1.0.2: {}
+
+  cosmiconfig@7.1.0:
+    dependencies:
+      '@types/parse-json': 4.0.2
+      import-fresh: 3.3.1
+      parse-json: 5.2.0
+      path-type: 4.0.0
+      yaml: 1.10.2
 
   cosmiconfig@8.3.6(typescript@5.8.3):
     dependencies:
@@ -2115,6 +2304,8 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  find-root@1.1.0: {}
+
   find-up@5.0.0:
     dependencies:
       locate-path: 6.0.0
@@ -2129,6 +2320,8 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  function-bind@1.1.2: {}
 
   gensync@1.0.0-beta.2: {}
 
@@ -2153,6 +2346,14 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hoist-non-react-statics@3.3.2:
+    dependencies:
+      react-is: 16.13.1
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -2165,6 +2366,10 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   is-arrayish@0.2.1: {}
+
+  is-core-module@2.16.1:
+    dependencies:
+      hasown: 2.0.2
 
   is-extglob@2.1.1: {}
 
@@ -2279,6 +2484,8 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  path-parse@1.0.7: {}
+
   path-type@4.0.0: {}
 
   picocolors@1.1.1: {}
@@ -2306,6 +2513,8 @@ snapshots:
       react: 19.1.0
       scheduler: 0.26.0
 
+  react-is@16.13.1: {}
+
   react-refresh@0.17.0: {}
 
   react-router@7.7.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
@@ -2322,6 +2531,12 @@ snapshots:
 
   resolve-pkg-maps@1.0.0:
     optional: true
+
+  resolve@1.22.10:
+    dependencies:
+      is-core-module: 2.16.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
 
   reusify@1.1.0: {}
 
@@ -2376,11 +2591,17 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  source-map@0.5.7: {}
+
   strip-json-comments@3.1.1: {}
+
+  stylis@4.2.0: {}
 
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  supports-preserve-symlinks-flag@1.0.0: {}
 
   svg-parser@2.0.4: {}
 
@@ -2468,5 +2689,7 @@ snapshots:
   word-wrap@1.2.5: {}
 
   yallist@3.1.1: {}
+
+  yaml@1.10.2: {}
 
   yocto-queue@0.1.0: {}

--- a/frontend/src/components/layouts/AdminHeader.tsx
+++ b/frontend/src/components/layouts/AdminHeader.tsx
@@ -1,0 +1,5 @@
+const AdminHeader = () => {
+  return <div>AdminHeader</div>;
+};
+
+export default AdminHeader;

--- a/frontend/src/components/layouts/CenterHeader.tsx
+++ b/frontend/src/components/layouts/CenterHeader.tsx
@@ -1,0 +1,5 @@
+const CenterHeader = () => {
+  return <div>CenterHeader</div>;
+};
+
+export default CenterHeader;

--- a/frontend/src/components/layouts/Header.tsx
+++ b/frontend/src/components/layouts/Header.tsx
@@ -1,0 +1,3 @@
+const Header = () => {};
+
+export default Header;

--- a/frontend/src/components/layouts/Header.tsx
+++ b/frontend/src/components/layouts/Header.tsx
@@ -1,3 +1,0 @@
-const Header = () => {};
-
-export default Header;

--- a/frontend/src/components/layouts/Sidebar.tsx
+++ b/frontend/src/components/layouts/Sidebar.tsx
@@ -1,0 +1,5 @@
+const Sidebar = () => {
+  return <div>Sidebar</div>;
+};
+
+export default Sidebar;

--- a/frontend/src/layouts/AdminLayout.tsx
+++ b/frontend/src/layouts/AdminLayout.tsx
@@ -1,0 +1,13 @@
+import AdminHeader from "@/components/layouts/AdminHeader";
+import { Outlet } from "react-router";
+
+const AdminLayout = () => {
+  return (
+    <div>
+      <AdminHeader />
+      <Outlet />
+    </div>
+  );
+};
+
+export default AdminLayout;

--- a/frontend/src/layouts/CenterLayout.tsx
+++ b/frontend/src/layouts/CenterLayout.tsx
@@ -1,0 +1,13 @@
+import CenterHeader from "@/components/layouts/CenterHeader";
+import { Outlet } from "react-router";
+
+const CenterLayout = () => {
+  return (
+    <div>
+      <CenterHeader />
+      <Outlet />
+    </div>
+  );
+};
+
+export default CenterLayout;

--- a/frontend/src/layouts/ReservationLayout.tsx
+++ b/frontend/src/layouts/ReservationLayout.tsx
@@ -1,0 +1,13 @@
+import Sidebar from "@/components/layouts/Sidebar";
+import { Outlet } from "react-router";
+
+const ReservationLayout = () => {
+  return (
+    <div>
+      <Sidebar />
+      <Outlet />
+    </div>
+  );
+};
+
+export default ReservationLayout;

--- a/frontend/src/layouts/index.ts
+++ b/frontend/src/layouts/index.ts
@@ -1,0 +1,3 @@
+export { default as AdminLayout } from "@/layouts/AdminLayout";
+export { default as CenterLayout } from "@/layouts/CenterLayout";
+export { default as ReservationLayout } from "@/layouts/ReservationLayout";

--- a/frontend/src/pages/admin/adminPage.tsx
+++ b/frontend/src/pages/admin/adminPage.tsx
@@ -1,0 +1,5 @@
+const AdminPage = () => {
+  return <>Admin</>;
+};
+
+export default AdminPage;

--- a/frontend/src/pages/admin/adminRegisterPage.tsx
+++ b/frontend/src/pages/admin/adminRegisterPage.tsx
@@ -1,0 +1,5 @@
+const AdminRegisterPage = () => {
+  return <>AdminRegister</>;
+};
+
+export default AdminRegisterPage;

--- a/frontend/src/pages/admin/drivers.tsx
+++ b/frontend/src/pages/admin/drivers.tsx
@@ -1,5 +1,0 @@
-const Drivers = () => {
-  return <>Drivers</>;
-};
-
-export default Drivers;

--- a/frontend/src/pages/admin/driversPage.tsx
+++ b/frontend/src/pages/admin/driversPage.tsx
@@ -1,0 +1,5 @@
+const DriversPage = () => {
+  return <>Drivers</>;
+};
+
+export default DriversPage;

--- a/frontend/src/pages/admin/index.tsx
+++ b/frontend/src/pages/admin/index.tsx
@@ -1,5 +1,0 @@
-const Admin = () => {
-  return <>Admin</>;
-};
-
-export default Admin;

--- a/frontend/src/pages/admin/register.tsx
+++ b/frontend/src/pages/admin/register.tsx
@@ -1,5 +1,0 @@
-const AdminRegister = () => {
-  return <>AdminRegister</>;
-};
-
-export default AdminRegister;

--- a/frontend/src/pages/admin/reservation/index.tsx
+++ b/frontend/src/pages/admin/reservation/index.tsx
@@ -1,5 +1,0 @@
-const Reservation = () => {
-  return <>Reservation</>;
-};
-
-export default Reservation;

--- a/frontend/src/pages/admin/reservation/paths.tsx
+++ b/frontend/src/pages/admin/reservation/paths.tsx
@@ -1,5 +1,0 @@
-const Paths = () => {
-  return <>Paths</>;
-};
-
-export default Paths;

--- a/frontend/src/pages/admin/reservation/pathsPage.tsx
+++ b/frontend/src/pages/admin/reservation/pathsPage.tsx
@@ -1,0 +1,5 @@
+const PathsPage = () => {
+  return <>Paths</>;
+};
+
+export default PathsPage;

--- a/frontend/src/pages/admin/reservation/reservationPage.tsx
+++ b/frontend/src/pages/admin/reservation/reservationPage.tsx
@@ -1,0 +1,5 @@
+const ReservationPage = () => {
+  return <>Reservation</>;
+};
+
+export default ReservationPage;

--- a/frontend/src/pages/admin/reservation/schedule.tsx
+++ b/frontend/src/pages/admin/reservation/schedule.tsx
@@ -1,5 +1,0 @@
-const Schedule = () => {
-  return <>Schedule</>;
-};
-
-export default Schedule;

--- a/frontend/src/pages/admin/reservation/schedulePage.tsx
+++ b/frontend/src/pages/admin/reservation/schedulePage.tsx
@@ -1,0 +1,5 @@
+const SchedulePage = () => {
+  return <>Schedule</>;
+};
+
+export default SchedulePage;

--- a/frontend/src/pages/admin/reservation/users.tsx
+++ b/frontend/src/pages/admin/reservation/users.tsx
@@ -1,5 +1,0 @@
-const Users = () => {
-  return <>Users</>;
-};
-
-export default Users;

--- a/frontend/src/pages/admin/reservation/usersPage.tsx
+++ b/frontend/src/pages/admin/reservation/usersPage.tsx
@@ -1,0 +1,5 @@
+const UsersPage = () => {
+  return <>Users</>;
+};
+
+export default UsersPage;

--- a/frontend/src/pages/admin/vehicles/[centerId].tsx
+++ b/frontend/src/pages/admin/vehicles/[centerId].tsx
@@ -1,5 +1,0 @@
-const CenterDetail = () => {
-  return <>CenterDetail</>;
-};
-
-export default CenterDetail;

--- a/frontend/src/pages/admin/vehicles/centerDetailPage.tsx
+++ b/frontend/src/pages/admin/vehicles/centerDetailPage.tsx
@@ -1,0 +1,5 @@
+const CenterDetailPage = () => {
+  return <>CenterDetail</>;
+};
+
+export default CenterDetailPage;

--- a/frontend/src/pages/admin/vehicles/index.tsx
+++ b/frontend/src/pages/admin/vehicles/index.tsx
@@ -1,5 +1,0 @@
-const Vehicles = () => {
-  return <>Vehicles</>;
-};
-
-export default Vehicles;

--- a/frontend/src/pages/admin/vehicles/vehiclesPage.tsx
+++ b/frontend/src/pages/admin/vehicles/vehiclesPage.tsx
@@ -1,0 +1,5 @@
+const VehiclesPage = () => {
+  return <>Vehicles</>;
+};
+
+export default VehiclesPage;

--- a/frontend/src/pages/center/centerPage.tsx
+++ b/frontend/src/pages/center/centerPage.tsx
@@ -1,0 +1,5 @@
+const CenterPage = () => {
+  return <>Center</>;
+};
+
+export default CenterPage;

--- a/frontend/src/pages/center/centerRegisterPage.tsx
+++ b/frontend/src/pages/center/centerRegisterPage.tsx
@@ -1,0 +1,5 @@
+const VehicleRegisterPage = () => {
+  return <>VehicleRegister</>;
+};
+
+export default VehicleRegisterPage;

--- a/frontend/src/pages/center/index.tsx
+++ b/frontend/src/pages/center/index.tsx
@@ -1,5 +1,0 @@
-const Center = () => {
-  return <>Center</>;
-};
-
-export default Center;

--- a/frontend/src/pages/center/register.tsx
+++ b/frontend/src/pages/center/register.tsx
@@ -1,5 +1,0 @@
-const VehicleRegister = () => {
-  return <>VehicleRegister</>;
-};
-
-export default VehicleRegister;

--- a/frontend/src/pages/index.ts
+++ b/frontend/src/pages/index.ts
@@ -1,0 +1,20 @@
+// Landing
+export { default as LandingPage } from "@/pages/landingPage";
+
+// Admin
+export { default as AdminPage } from "@/pages/admin/adminPage";
+export { default as DriversPage } from "@/pages/admin/driversPage";
+export { default as AdminRegisterPage } from "@/pages/admin/adminRegisterPage";
+export { default as ReservationPage } from "@/pages/admin/reservation/reservationPage";
+export { default as PathsPage } from "@/pages/admin/reservation/pathsPage";
+export { default as SchedulePage } from "@/pages/admin/reservation/schedulePage";
+export { default as UsersPage } from "@/pages/admin/reservation/usersPage";
+export { default as VehiclesPage } from "@/pages/admin/vehicles/vehiclesPage";
+export { default as CenterDetailPage } from "@/pages/admin/vehicles/centerDetailPage";
+
+// Center
+export { default as CenterPage } from "@/pages/center/centerPage";
+export { default as VehicleRegisterPage } from "@/pages/center/centerRegisterPage";
+
+// NotFound
+export { default as NotFoundPage } from "@/pages/notFoundPage";

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,5 +1,0 @@
-const Landing = () => {
-  return <>Landing</>;
-};
-
-export default Landing;

--- a/frontend/src/pages/landingPage.tsx
+++ b/frontend/src/pages/landingPage.tsx
@@ -1,0 +1,5 @@
+const LandingPage = () => {
+  return <>Landing</>;
+};
+
+export default LandingPage;

--- a/frontend/src/pages/notFound.tsx
+++ b/frontend/src/pages/notFound.tsx
@@ -1,5 +1,0 @@
-const NotFound = () => {
-  return <>Not Found</>;
-};
-
-export default NotFound;

--- a/frontend/src/pages/notFoundPage.tsx
+++ b/frontend/src/pages/notFoundPage.tsx
@@ -1,0 +1,5 @@
+const NotFoundPage = () => {
+  return <>Not Found</>;
+};
+
+export default NotFoundPage;

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,16 +1,18 @@
-import LandingPage from "@/pages/landingPage";
-import AdminPage from "@/pages/admin/adminPage";
-import DriversPage from "@/pages/admin/driversPage";
-import AdminRegisterPage from "@/pages/admin/adminRegisterPage";
-import ReservationPage from "@/pages/admin/reservation/reservationPage";
-import PathsPage from "@/pages/admin/reservation/pathsPage";
-import SchedulePage from "@/pages/admin/reservation/schedulePage";
-import UsersPage from "@/pages/admin/reservation/usersPage";
-import VehiclesPage from "@/pages/admin/vehicles/vehiclesPage";
-import CenterDetailPage from "@/pages/admin/vehicles/centerDetailPage";
-import CenterPage from "@/pages/center/centerPage";
-import VehicleRegisterPage from "@/pages/center/centerRegisterPage";
-import NotFoundPage from "@/pages/notFoundPage";
+import {
+  LandingPage,
+  AdminPage,
+  DriversPage,
+  AdminRegisterPage,
+  ReservationPage,
+  PathsPage,
+  SchedulePage,
+  UsersPage,
+  VehiclesPage,
+  CenterDetailPage,
+  CenterPage,
+  VehicleRegisterPage,
+  NotFoundPage,
+} from "@/pages";
 import { BrowserRouter, Route, Routes } from "react-router";
 
 const Router = () => {

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,16 +1,16 @@
-import Landing from "@/pages";
-import Admin from "@/pages/admin";
-import Drivers from "@/pages/admin/drivers";
-import AdminRegister from "@/pages/admin/register";
-import Reservation from "@/pages/admin/reservation";
-import Paths from "@/pages/admin/reservation/paths";
-import Schedule from "@/pages/admin/reservation/schedule";
-import Users from "@/pages/admin/reservation/users";
-import Vehicles from "@/pages/admin/vehicles";
-import CenterDetail from "@/pages/admin/vehicles/[centerId]";
-import Center from "@/pages/center";
-import VehicleRegister from "@/pages/center/register";
-import NotFound from "@/pages/notFound";
+import LandingPage from "@/pages/landingPage";
+import AdminPage from "@/pages/admin/adminPage";
+import DriversPage from "@/pages/admin/driversPage";
+import AdminRegisterPage from "@/pages/admin/adminRegisterPage";
+import ReservationPage from "@/pages/admin/reservation/reservationPage";
+import PathsPage from "@/pages/admin/reservation/pathsPage";
+import SchedulePage from "@/pages/admin/reservation/schedulePage";
+import UsersPage from "@/pages/admin/reservation/usersPage";
+import VehiclesPage from "@/pages/admin/vehicles/vehiclesPage";
+import CenterDetailPage from "@/pages/admin/vehicles/centerDetailPage";
+import CenterPage from "@/pages/center/centerPage";
+import VehicleRegisterPage from "@/pages/center/centerRegisterPage";
+import NotFoundPage from "@/pages/notFoundPage";
 import { BrowserRouter, Route, Routes } from "react-router";
 
 const Router = () => {
@@ -19,32 +19,32 @@ const Router = () => {
       <Routes>
         {/* Admin 영역 */}
         <Route path="/admin">
-          <Route index element={<Admin />} />
+          <Route index element={<AdminPage />} />
           <Route path="reservation">
-            <Route index element={<Reservation />} />
-            <Route path="schedule" element={<Schedule />} />
-            <Route path="users" element={<Users />} />
-            <Route path="paths" element={<Paths />} />
-            <Route path="register" element={<AdminRegister />} />
+            <Route index element={<ReservationPage />} />
+            <Route path="schedule" element={<SchedulePage />} />
+            <Route path="users" element={<UsersPage />} />
+            <Route path="paths" element={<PathsPage />} />
+            <Route path="register" element={<AdminRegisterPage />} />
           </Route>
           <Route path="vehicles">
-            <Route index element={<Vehicles />} />
-            <Route path=":id" element={<CenterDetail />} />
+            <Route index element={<VehiclesPage />} />
+            <Route path=":id" element={<CenterDetailPage />} />
           </Route>
-          <Route path="drivers" element={<Drivers />} />
+          <Route path="drivers" element={<DriversPage />} />
         </Route>
 
         {/* Center 영역 */}
         <Route path="/center">
-          <Route index element={<Center />} />
-          <Route path="register" element={<VehicleRegister />} />
+          <Route index element={<CenterPage />} />
+          <Route path="register" element={<VehicleRegisterPage />} />
         </Route>
 
         {/* 초기 진입 시 리디렉션 */}
-        <Route path="/" element={<Landing />} />
+        <Route path="/" element={<LandingPage />} />
 
         {/* Not found */}
-        <Route path="/*" element={<NotFound />} />
+        <Route path="/*" element={<NotFoundPage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -1,3 +1,4 @@
+import { AdminLayout, CenterLayout, ReservationLayout } from "@/layouts";
 import {
   LandingPage,
   AdminPage,
@@ -20,9 +21,9 @@ const Router = () => {
     <BrowserRouter>
       <Routes>
         {/* Admin 영역 */}
-        <Route path="/admin">
+        <Route path="/admin/*" element={<AdminLayout />}>
           <Route index element={<AdminPage />} />
-          <Route path="reservation">
+          <Route path="reservation" element={<ReservationLayout />}>
             <Route index element={<ReservationPage />} />
             <Route path="schedule" element={<SchedulePage />} />
             <Route path="users" element={<UsersPage />} />
@@ -37,7 +38,7 @@ const Router = () => {
         </Route>
 
         {/* Center 영역 */}
-        <Route path="/center">
+        <Route path="/center/*" element={<CenterLayout />}>
           <Route index element={<CenterPage />} />
           <Route path="register" element={<VehicleRegisterPage />} />
         </Route>


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Close #19 

## 📝 기능 설명
페이지별로 레이아웃을 분리하고, 관련된 라우팅에 화면이 보이도록 설정했습니다.

## 🛠 작업 사항
- 중첩된 구조에서의 레이아웃 분리를 구현했습니다. 특정 페이지 하위에서 항상 동일한 레이아웃이 적용됨을 명시적으로 나타내기 위하여 경로의 뒤에 전체를 나타내는 *를 표기했습니다.
  - 기존 path: path="/admin"
  - 변경된 path: path="/admin/*" 
- index.ts의 역할을 "import하는 구문 모아두는 역할"로 명확하게 설정했습니다.
  - 기존 index.ts의 역할: import하는 구문 모아두는 역할+페이지의 default를 나타내는 역할(혼잡)
  - 변경된 index.ts의 역할: import하는 구문 모아두는 역할(명확! 👍)

## ✅ 작업 항목
- [x] 페이지 컴포넌트 이름 변경
- [x] 레이아웃 컴포넌트 구현
- [x] 레이아웃 내부에 <Outlet /> 삽입
- [x] 라우팅 파일에 레이아웃 적용
- [x] emotion 의존성 설치

## 📎 참고 자료
### 관리자용 화면에서 레이아웃 분리(헤더 및 사이드바 적용)
<img width="1037" height="274" alt="image" src="https://github.com/user-attachments/assets/7f29d359-1ddf-4d21-90ad-891df9a8453b" />

### 센터용 화면에서 레이아웃 분리
<img width="1078" height="335" alt="image" src="https://github.com/user-attachments/assets/e3cf88e8-4c8e-453b-8bf1-6ff7f385cc1f" />
