### PR TITLE
[ Feat/#28 ] Domain 별 Controller, Service, Repository 생성

### DIFF
--- a/backend/src/main/java/hyfive/gachita/book/Book.java
+++ b/backend/src/main/java/hyfive/gachita/book/Book.java
@@ -1,0 +1,86 @@
+package hyfive.gachita.book;
+
+import hyfive.gachita.path.Path;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "book")
+public class Book {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "book_id", nullable = false, columnDefinition = "BIGINT")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "path_id")
+    private Path path;
+
+    @NotNull
+    @Column(name = "book_name", nullable = false, columnDefinition = "VARCHAR(255)")
+    private String bookName;
+
+    @NotNull
+    @Column(name = "book_tel", nullable = false, columnDefinition = "VARCHAR(255)")
+    private String bookTel;
+
+    @NotNull
+    @Column(name = "book_date", nullable = false, columnDefinition = "DATE")
+    private LocalDate bookDate;
+
+    @NotNull
+    @Column(name = "start_addr", nullable = false, columnDefinition = "VARCHAR(255)")
+    private String startAddr;
+
+    @NotNull
+    @Column(name = "end_addr", nullable = false, columnDefinition = "VARCHAR(255)")
+    private String endAddr;
+
+    @NotNull
+    @Column(name = "walker", nullable = false, columnDefinition = "BOOLEAN")
+    private Boolean walker;
+
+    @NotNull
+    @Column(name = "hospital_book_time", nullable = false, columnDefinition = "TIME")
+    private LocalTime hospitalBookTime;
+
+    @NotNull
+    @Column(name = "deadline", nullable = false, columnDefinition = "TIME")
+    private LocalTime deadline;
+
+    @NotNull
+    @Column(name = "start_lat", nullable = false, columnDefinition = "DECIMAL(9,6)")
+    private double startLat;
+
+    @NotNull
+    @Column(name = "start_lon", nullable = false, columnDefinition = "DECIMAL(9,6)")
+    private double startLon;
+
+    @NotNull
+    @Column(name = "end_lat", nullable = false, columnDefinition = "DECIMAL(9,6)")
+    private double endLat;
+
+    @NotNull
+    @Column(name = "end_lon", nullable = false, columnDefinition = "DECIMAL(9,6)")
+    private double endLon;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "book_status", nullable = false, columnDefinition = "VARCHAR(50)")
+    private BookStatus bookStatus;
+
+    @NotNull
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, columnDefinition = "TIMESTAMP")
+    private LocalDateTime createdAt;
+}
+

--- a/backend/src/main/java/hyfive/gachita/book/BookController.java
+++ b/backend/src/main/java/hyfive/gachita/book/BookController.java
@@ -1,0 +1,11 @@
+package hyfive.gachita.book;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/book")
+@RequiredArgsConstructor
+public class BookController {
+}

--- a/backend/src/main/java/hyfive/gachita/book/BookRepository.java
+++ b/backend/src/main/java/hyfive/gachita/book/BookRepository.java
@@ -1,0 +1,6 @@
+package hyfive.gachita.book;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookRepository extends JpaRepository<Book, Long> {
+}

--- a/backend/src/main/java/hyfive/gachita/book/BookService.java
+++ b/backend/src/main/java/hyfive/gachita/book/BookService.java
@@ -1,0 +1,10 @@
+package hyfive.gachita.book;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BookService {
+    private final BookRepository bookRepository;
+}

--- a/backend/src/main/java/hyfive/gachita/book/BookStatus.java
+++ b/backend/src/main/java/hyfive/gachita/book/BookStatus.java
@@ -1,0 +1,17 @@
+package hyfive.gachita.book;
+
+import lombok.Getter;
+
+@Getter
+public enum BookStatus {
+    NEW("신규예약"),
+    SUCCESS("예약성공"),
+    FAIL("예약실패"),
+    FIXED("경로확정");
+
+    private String value;
+
+    BookStatus(String value) {
+        this.value = value;
+    }
+}

--- a/backend/src/main/java/hyfive/gachita/car/Car.java
+++ b/backend/src/main/java/hyfive/gachita/car/Car.java
@@ -1,0 +1,56 @@
+package hyfive.gachita.car;
+
+import hyfive.gachita.center.Center;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "car")
+public class Car {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "car_id", nullable = false, columnDefinition = "BIGINT")
+    private Long id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "center_id", nullable = false)
+    private Center center;
+
+    @NotNull
+    @Column(name = "model_name", nullable = false, columnDefinition = "VARCHAR(255)")
+    private String modelName;
+
+    @NotNull
+    @Column(name = "car_number", nullable = false, columnDefinition = "VARCHAR(255)")
+    private String carNumber;
+
+    @NotNull
+    @Column(name = "capacity", nullable = false, columnDefinition = "INT")
+    private Integer capacity;
+
+    @NotNull
+    @Column(name = "low_floor", nullable = false, columnDefinition = "BOOLEAN")
+    private Boolean lowFloor;
+
+    @Column(name = "car_image", columnDefinition = "VARCHAR(255)")
+    private String carImage;
+
+    @NotNull
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, columnDefinition = "TIMESTAMP")
+    private LocalDateTime createdAt;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "del_yn", nullable = false, columnDefinition = "VARCHAR(50)")
+    private DelYn delYn = DelYn.N;;
+}
+

--- a/backend/src/main/java/hyfive/gachita/car/CarController.java
+++ b/backend/src/main/java/hyfive/gachita/car/CarController.java
@@ -1,0 +1,12 @@
+package hyfive.gachita.car;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/car")
+@RequiredArgsConstructor
+public class CarController {
+    private final CarService carService;
+}

--- a/backend/src/main/java/hyfive/gachita/car/CarRepository.java
+++ b/backend/src/main/java/hyfive/gachita/car/CarRepository.java
@@ -1,0 +1,6 @@
+package hyfive.gachita.car;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CarRepository extends JpaRepository<Car, Long> {
+}

--- a/backend/src/main/java/hyfive/gachita/car/CarService.java
+++ b/backend/src/main/java/hyfive/gachita/car/CarService.java
@@ -1,0 +1,10 @@
+package hyfive.gachita.car;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CarService {
+    private final CarRepository carRepository;
+}

--- a/backend/src/main/java/hyfive/gachita/car/DelYn.java
+++ b/backend/src/main/java/hyfive/gachita/car/DelYn.java
@@ -1,0 +1,6 @@
+package hyfive.gachita.car;
+
+public enum DelYn {
+    Y,
+    N
+}

--- a/backend/src/main/java/hyfive/gachita/center/Center.java
+++ b/backend/src/main/java/hyfive/gachita/center/Center.java
@@ -1,0 +1,45 @@
+package hyfive.gachita.center;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "center")
+public class Center {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "center_id", nullable = false, columnDefinition = "BIGINT")
+    private Long id;
+
+    @NotNull
+    @Column(name = "center_name", nullable = false, columnDefinition = "VARCHAR(255)")
+    private String centerName;
+
+    @NotNull
+    @Column(name = "center_tel", nullable = false, columnDefinition = "VARCHAR(255)")
+    private String centerTel;
+
+    @NotNull
+    @Column(name = "center_addr", nullable = false, columnDefinition = "VARCHAR(255)")
+    private String centerAddr;
+
+    @NotNull
+    @Column(name = "lat", nullable = false, columnDefinition = "DECIMAL(9,6)")
+    private double lat;
+
+    @NotNull
+    @Column(name = "lon", nullable = false, columnDefinition = "DECIMAL(9,6)")
+    private double lon;
+
+    @NotNull
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, columnDefinition = "TIMESTAMP")
+    private LocalDateTime createdAt;
+}
+

--- a/backend/src/main/java/hyfive/gachita/center/CenterController.java
+++ b/backend/src/main/java/hyfive/gachita/center/CenterController.java
@@ -1,0 +1,12 @@
+package hyfive.gachita.center;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/center")
+@RequiredArgsConstructor
+public class CenterController {
+    private final CenterService centerService;
+}

--- a/backend/src/main/java/hyfive/gachita/center/CenterRepository.java
+++ b/backend/src/main/java/hyfive/gachita/center/CenterRepository.java
@@ -1,0 +1,8 @@
+package hyfive.gachita.center;
+
+import hyfive.gachita.test.Test;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CenterRepository extends JpaRepository<Center, Long> {
+}
+

--- a/backend/src/main/java/hyfive/gachita/center/CenterRepository.java
+++ b/backend/src/main/java/hyfive/gachita/center/CenterRepository.java
@@ -1,6 +1,5 @@
 package hyfive.gachita.center;
 
-import hyfive.gachita.test.Test;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CenterRepository extends JpaRepository<Center, Long> {

--- a/backend/src/main/java/hyfive/gachita/center/CenterService.java
+++ b/backend/src/main/java/hyfive/gachita/center/CenterService.java
@@ -1,0 +1,10 @@
+package hyfive.gachita.center;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CenterService {
+    private final CenterRepository centerRepository;
+}

--- a/backend/src/main/java/hyfive/gachita/node/Node.java
+++ b/backend/src/main/java/hyfive/gachita/node/Node.java
@@ -1,0 +1,49 @@
+package hyfive.gachita.node;
+
+import hyfive.gachita.path.Path;
+import hyfive.gachita.book.Book;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalTime;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "node")
+public class Node {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "node_id", nullable = false, columnDefinition = "BIGINT")
+    private Long id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "path_id", nullable = false)
+    private Path path;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "book_id", nullable = false)
+    private Book book;
+
+    @NotNull
+    @Column(name = "lat", nullable = false, columnDefinition = "DECIMAL(9,6)")
+    private double lat;
+
+    @NotNull
+    @Column(name = "lon", nullable = false, columnDefinition = "DECIMAL(9,6)")
+    private double lon;
+
+    @NotNull
+    @Column(name = "time", nullable = false, columnDefinition = "TIME")
+    private LocalTime time;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, columnDefinition = "VARCHAR(50)")
+    private NodeType type;
+}
+

--- a/backend/src/main/java/hyfive/gachita/node/NodeController.java
+++ b/backend/src/main/java/hyfive/gachita/node/NodeController.java
@@ -1,0 +1,12 @@
+package hyfive.gachita.node;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/node")
+@RequiredArgsConstructor
+public class NodeController {
+    private final NodeService nodeService;
+}

--- a/backend/src/main/java/hyfive/gachita/node/NodeRepository.java
+++ b/backend/src/main/java/hyfive/gachita/node/NodeRepository.java
@@ -1,0 +1,6 @@
+package hyfive.gachita.node;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NodeRepository extends JpaRepository<Node, Long> {
+}

--- a/backend/src/main/java/hyfive/gachita/node/NodeService.java
+++ b/backend/src/main/java/hyfive/gachita/node/NodeService.java
@@ -1,0 +1,10 @@
+package hyfive.gachita.node;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NodeService {
+    private final NodeRepository nodeRepository;
+}

--- a/backend/src/main/java/hyfive/gachita/node/NodeType.java
+++ b/backend/src/main/java/hyfive/gachita/node/NodeType.java
@@ -1,0 +1,6 @@
+package hyfive.gachita.node;
+
+public enum NodeType {
+    START,
+    END;
+}

--- a/backend/src/main/java/hyfive/gachita/path/DriveStatus.java
+++ b/backend/src/main/java/hyfive/gachita/path/DriveStatus.java
@@ -1,0 +1,16 @@
+package hyfive.gachita.path;
+
+import lombok.Getter;
+
+@Getter
+public enum DriveStatus {
+    WAITING("운행대기"),
+    RUNNING("운행중"),
+    FINISHED("운행완료");
+
+    private final String value;
+
+    DriveStatus(String value) {
+        this.value = value;
+    }
+}

--- a/backend/src/main/java/hyfive/gachita/path/Path.java
+++ b/backend/src/main/java/hyfive/gachita/path/Path.java
@@ -1,0 +1,63 @@
+package hyfive.gachita.path;
+
+import hyfive.gachita.car.Car;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "path")
+public class Path {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "path_id", nullable = false, columnDefinition = "BIGINT")
+    private Long id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "car_id", nullable = false)
+    private Car car;
+
+    @NotNull
+    @Column(name = "maybe_start_time", nullable = false, columnDefinition = "TIME")
+    private LocalTime maybeStartTime;
+
+    @NotNull
+    @Column(name = "maybe_end_time", nullable = false, columnDefinition = "TIME")
+    private LocalTime maybeEndTime;
+
+    @NotNull
+    @Column(name = "real_start_time", nullable = false, columnDefinition = "TIME")
+    private LocalTime realStartTime;
+
+    @NotNull
+    @Column(name = "real_end_time", nullable = false, columnDefinition = "TIME")
+    private LocalTime realEndTime;
+
+    @NotNull
+    @Column(name = "drive_date", nullable = false, columnDefinition = "DATE")
+    private LocalDate driveDate;
+
+    @NotNull
+    @Column(name = "start_addr", nullable = false, columnDefinition = "VARCHAR(255)")
+    private String startAddr;
+
+    @NotNull
+    @Column(name = "end_addr", nullable = false, columnDefinition = "VARCHAR(255)")
+    private String endAddr;
+
+    @NotNull
+    @Column(name = "user_count", nullable = false, columnDefinition = "INT")
+    private Integer userCount;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(name = "drive_status", nullable = false, columnDefinition = "VARCHAR(50)")
+    private DriveStatus driveStatus = DriveStatus.WAITING;
+}

--- a/backend/src/main/java/hyfive/gachita/path/PathController.java
+++ b/backend/src/main/java/hyfive/gachita/path/PathController.java
@@ -1,0 +1,12 @@
+package hyfive.gachita.path;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/path")
+@RequiredArgsConstructor
+public class PathController {
+    private final PathService pathService;
+}

--- a/backend/src/main/java/hyfive/gachita/path/PathRepository.java
+++ b/backend/src/main/java/hyfive/gachita/path/PathRepository.java
@@ -1,0 +1,6 @@
+package hyfive.gachita.path;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PathRepository extends JpaRepository<Path, Long> {
+}

--- a/backend/src/main/java/hyfive/gachita/path/PathService.java
+++ b/backend/src/main/java/hyfive/gachita/path/PathService.java
@@ -1,0 +1,10 @@
+package hyfive.gachita.path;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PathService {
+    private final PathRepository pathRepository;
+}

--- a/backend/src/main/java/hyfive/gachita/pay/Pay.java
+++ b/backend/src/main/java/hyfive/gachita/pay/Pay.java
@@ -1,0 +1,40 @@
+package hyfive.gachita.pay;
+
+
+import hyfive.gachita.book.Book;
+import hyfive.gachita.center.Center;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "pay")
+public class Pay {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "pay_id", nullable = false, columnDefinition = "BIGINT")
+    private Long id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "book_id", nullable = false)
+    private Book book;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "center_id", nullable = false)
+    private Center center;
+
+    @NotNull
+    @Column(name = "amount", nullable = false, columnDefinition = "INT DEFAULT 0")
+    private Integer amount = 0;
+
+    @NotNull
+    @Column(name = "pay_date", nullable = false, columnDefinition = "DATE")
+    private LocalDate payDate;
+}

--- a/backend/src/main/java/hyfive/gachita/pay/PayController.java
+++ b/backend/src/main/java/hyfive/gachita/pay/PayController.java
@@ -1,0 +1,12 @@
+package hyfive.gachita.pay;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/pay")
+@RequiredArgsConstructor
+public class PayController {
+    private final PayService payService;
+}

--- a/backend/src/main/java/hyfive/gachita/pay/PayRepository.java
+++ b/backend/src/main/java/hyfive/gachita/pay/PayRepository.java
@@ -1,0 +1,6 @@
+package hyfive.gachita.pay;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PayRepository extends JpaRepository<Pay, Long> {
+}

--- a/backend/src/main/java/hyfive/gachita/pay/PayService.java
+++ b/backend/src/main/java/hyfive/gachita/pay/PayService.java
@@ -1,0 +1,10 @@
+package hyfive.gachita.pay;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PayService {
+    private final PayRepository payRepository;
+}

--- a/backend/src/main/java/hyfive/gachita/rental/Rental.java
+++ b/backend/src/main/java/hyfive/gachita/rental/Rental.java
@@ -1,0 +1,39 @@
+package hyfive.gachita.rental;
+
+import hyfive.gachita.car.Car;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "rental")
+public class Rental {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "rental_id", nullable = false, columnDefinition = "BIGINT")
+    private Long id;
+
+    @NotNull
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "car_id", nullable = false)
+    private Car car;
+
+    @NotNull
+    @Column(name = "rental_date", nullable = false, columnDefinition = "DATE")
+    private LocalDate rentalDate;
+
+    @NotNull
+    @Column(name = "rental_start_time", nullable = false, columnDefinition = "TIME")
+    private LocalTime rentalStartTime;
+
+    @NotNull
+    @Column(name = "rental_end_time", nullable = false, columnDefinition = "TIME")
+    private LocalTime rentalEndTime;
+}
+

--- a/backend/src/main/java/hyfive/gachita/rental/RentalController.java
+++ b/backend/src/main/java/hyfive/gachita/rental/RentalController.java
@@ -1,0 +1,12 @@
+package hyfive.gachita.rental;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/rental")
+@RequiredArgsConstructor
+public class RentalController {
+    private final RentalService rentalService;
+}

--- a/backend/src/main/java/hyfive/gachita/rental/RentalRepository.java
+++ b/backend/src/main/java/hyfive/gachita/rental/RentalRepository.java
@@ -1,0 +1,6 @@
+package hyfive.gachita.rental;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RentalRepository extends JpaRepository<Rental, Long> {
+}

--- a/backend/src/main/java/hyfive/gachita/rental/RentalService.java
+++ b/backend/src/main/java/hyfive/gachita/rental/RentalService.java
@@ -1,0 +1,10 @@
+package hyfive.gachita.rental;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RentalService {
+    private final RentalRepository rentalRepository;
+}

--- a/backend/src/main/resources/schema.sql
+++ b/backend/src/main/resources/schema.sql
@@ -1,0 +1,165 @@
+﻿CREATE TABLE `path` (
+	`path_id`	long	NOT NULL,
+	`car_id`	long	NOT NULL,
+	`maybe_start_time`	time	NOT NULL,
+	`maybe_end_time`	time	NOT NULL,
+	`real_start_time`	time	NOT NULL,
+	`real_end_time`	time	NOT NULL,
+	`drive_date`	date	NOT NULL,
+	`start_addr`	varchar(255)	NOT NULL,
+	`end_addr`	varchar(255)	NOT NULL,
+	`user_count`	int	NOT NULL,
+	`drive_status`	varchar(50)	NOT NULL	DEFAULT 운행대기	COMMENT '운행대기, 운행중, 운행완료'
+);
+
+CREATE TABLE `node` (
+	`node_id`	long	NOT NULL,
+	`path_id`	long	NOT NULL,
+	`book_id`	long	NOT NULL,
+	`lat`	DECIMAL(9,6)	NOT NULL,
+	`lon`	DECIMAL(9,6)	NOT NULL,
+	`time`	time	NOT NULL,
+	`type`	varchar(50)	NOT NULL	COMMENT 'START, END'
+);
+
+CREATE TABLE `car` (
+	`car_id`	long	NOT NULL,
+	`center_id2`	long	NOT NULL,
+	`model_name`	varchar(255)	NOT NULL,
+	`car_number`	varchar(255)	NOT NULL,
+	`capacity`	int	NOT NULL,
+	`low_floor`	boolean	NOT NULL,
+	`car_image`	varchar(255)	NULL	COMMENT 'uuid 파일이름',
+	`created_at`	timestamp	NOT NULL,
+	`del_yn`	varchar(50)	NOT NULL
+);
+
+CREATE TABLE `pay` (
+	`pay_id`	long	NOT NULL,
+	`book_id2`	long	NOT NULL,
+	`center_id2`	long	NOT NULL,
+	`amount`	int	NOT NULL	DEFAULT 0,
+	`pay_date`	date	NOT NULL
+);
+
+CREATE TABLE `book` (
+	`book_id`	long	NOT NULL,
+	`path_id`	long	NULL,
+	`book_name`	varchar(255)	NOT NULL,
+	`book_tel`	varchar(255)	NOT NULL,
+	`book_date`	date	NOT NULL,
+	`start_addr`	varchar(255)	NOT NULL,
+	`end_addr`	varchar(255)	NOT NULL,
+	`walker`	boolean	NOT NULL,
+	`hospital_book_time`	time	NOT NULL,
+	`deadline`	time	NOT NULL	COMMENT '병원 도착 시간 - 30분',
+	`start_lat`	DECIMAL(9,6)	NOT NULL,
+	`start_lon`	DECIMAL(9,6)	NOT NULL,
+	`end_lat`	DECIMAL(9,6)	NOT NULL,
+	`end_lon`	DECIMAL(9,6)	NOT NULL,
+	`book_status`	varchar(50)	NOT NULL	DEFAULT 신규예약	COMMENT '신규예약, 예약성공, 예약실패, 경로확정',
+	`created_at`	timestamp	NOT NULL
+);
+
+CREATE TABLE `rental` (
+	`rental_id`	long	NOT NULL,
+	`car_id`	long	NOT NULL,
+	`rental_date`	date	NOT NULL,
+	`rental_start_time`	time	NOT NULL,
+	`rental_end_time`	time	NOT NULL
+);
+
+CREATE TABLE `center` (
+	`center_id`	long	NOT NULL,
+	`center_name`	varchar(255)	NOT NULL,
+	`center_tel`	varchar(255)	NOT NULL,
+	`center_addr`	varchar(255)	NOT NULL,
+	`lat`	DECIMAL(9,6)	NOT NULL,
+	`lon`	DECIMAL(9,6)	NOT NULL,
+	`created_at`	timestamp	NOT NULL
+);
+
+ALTER TABLE `path` ADD CONSTRAINT `PK_PATH` PRIMARY KEY (
+	`path_id`
+);
+
+ALTER TABLE `node` ADD CONSTRAINT `PK_NODE` PRIMARY KEY (
+	`node_id`
+);
+
+ALTER TABLE `car` ADD CONSTRAINT `PK_CAR` PRIMARY KEY (
+	`car_id`
+);
+
+ALTER TABLE `pay` ADD CONSTRAINT `PK_PAY` PRIMARY KEY (
+	`pay_id`
+);
+
+ALTER TABLE `book` ADD CONSTRAINT `PK_BOOK` PRIMARY KEY (
+	`book_id`
+);
+
+ALTER TABLE `rental` ADD CONSTRAINT `PK_RENTAL` PRIMARY KEY (
+	`rental_id`
+);
+
+ALTER TABLE `center` ADD CONSTRAINT `PK_CENTER` PRIMARY KEY (
+	`center_id`
+);
+
+ALTER TABLE `path` ADD CONSTRAINT `FK_car_TO_path_1` FOREIGN KEY (
+	`car_id`
+)
+REFERENCES `car` (
+	`car_id`
+);
+
+ALTER TABLE `node` ADD CONSTRAINT `FK_path_TO_node_1` FOREIGN KEY (
+	`path_id`
+)
+REFERENCES `path` (
+	`path_id`
+);
+
+ALTER TABLE `node` ADD CONSTRAINT `FK_book_TO_node_1` FOREIGN KEY (
+	`book_id`
+)
+REFERENCES `book` (
+	`book_id`
+);
+
+ALTER TABLE `car` ADD CONSTRAINT `FK_center_TO_car_1` FOREIGN KEY (
+	`center_id2`
+)
+REFERENCES `center` (
+	`center_id`
+);
+
+ALTER TABLE `pay` ADD CONSTRAINT `FK_book_TO_pay_1` FOREIGN KEY (
+	`book_id2`
+)
+REFERENCES `book` (
+	`book_id`
+);
+
+ALTER TABLE `pay` ADD CONSTRAINT `FK_center_TO_pay_1` FOREIGN KEY (
+	`center_id2`
+)
+REFERENCES `center` (
+	`center_id`
+);
+
+ALTER TABLE `book` ADD CONSTRAINT `FK_path_TO_book_1` FOREIGN KEY (
+	`path_id`
+)
+REFERENCES `path` (
+	`path_id`
+);
+
+ALTER TABLE `rental` ADD CONSTRAINT `FK_car_TO_rental_1` FOREIGN KEY (
+	`car_id`
+)
+REFERENCES `car` (
+	`car_id`
+);
+


### PR DESCRIPTION
## #️⃣ 연관된 이슈
Close #28 

## 📝 기능 설명
domain 별 controller, service, repository, entity, enum 생성

## 🛠 작업 사항

### Entity 클래스 annotation 설정
1. Id 칼럼의 GeneratedValue
```java
@GeneratedValue(strategy = GenerationType.IDENTITY)
```
2. Column
```java
@Column(name = "?", nullable = ?, columnDefinition = "?")
```
3. ManyTOne
```java
@ManyToOne(fetch = FetchType.LAZY)
```
4. Enumerated
```java
@Enumerated(EnumType.STRING)
```

### 특이 사항
1. `created_at` 칼럼은 `@CreationTimestamp`으로 레코드 생성 일시를 자동으로 입력하게 설정
2. `Car` 엔티티의 `del_yn` 칼럼은 `DelYn.N`을 default로 설정

### 논의가 필요한 사항
1. `OneToMany`를 추가할 것인지
2. `Pay` 엔티티의 `amount` 칼럼의 default 값을 0으로 설정해둘 것인지
3. 각 테이블의 위도, 경도 칼럼명

## ✅ 작업 항목
### domain 목록
- [ ] center
- [ ] car
- [ ] rental
- [ ] path
- [ ] book
- [ ] pay
- [ ] node

## 📎 참고 자료
(없음)