### PR TITLE
[ Feat/#105 ] 센터 정보 컴포넌트 구현

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "format": "prettier --check .",
     "typecheck": "tsc --noEmit",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:ui": "vitest --ui"
   },
   "dependencies": {
     "date-fns": "^4.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit",
     "build": "vite build",
     "preview": "vite preview",
-    "test:ui": "vitest --ui"
+    "test": "vitest --ui"
   },
   "dependencies": {
     "date-fns": "^4.1.0",

--- a/frontend/src/features/CenterOverview/CenterInfoCard.tsx
+++ b/frontend/src/features/CenterOverview/CenterInfoCard.tsx
@@ -3,7 +3,7 @@ import { theme } from "@/styles/themes.style";
 
 const { color, typography } = theme;
 
-export interface CenterInfoCardProps {
+interface CenterInfoCardProps {
   icon: React.ReactNode;
   label: string;
   content: string;

--- a/frontend/src/features/CenterOverview/CenterInfoCard.tsx
+++ b/frontend/src/features/CenterOverview/CenterInfoCard.tsx
@@ -1,0 +1,48 @@
+import { css } from "@emotion/react";
+import { theme } from "@/styles/themes.style";
+
+const { color, typography } = theme;
+
+export interface CenterInfoCardProps {
+  icon: React.ReactNode;
+  label: string;
+  content: string;
+}
+
+const CenterInfoCard = ({ icon, label, content }: CenterInfoCardProps) => {
+  return (
+    <div css={CardContainer}>
+      <div css={CardHeader}>
+        {icon}
+        <p css={CardLabel}>{label}</p>
+      </div>
+      <div css={CardContent}>{content}</div>
+    </div>
+  );
+};
+
+export default CenterInfoCard;
+
+const CardContainer = css`
+  display: flex;
+  width: 460px;
+  padding: 20px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+`;
+
+const CardHeader = css`
+  display: flex;
+  gap: 12px;
+`;
+
+const CardLabel = css`
+  font: ${typography.Body.b3_medi};
+  color: ${color.GrayScale.gray4};
+`;
+
+const CardContent = css`
+  font: ${typography.Label.l2_semi};
+  color: ${color.GrayScale.gray6};
+`;

--- a/frontend/src/features/CenterOverview/CenterOverview.test.tsx
+++ b/frontend/src/features/CenterOverview/CenterOverview.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import type { CenterOverviewType } from "@/features/CenterOverview/CenterOverview.type";
+import CenterOverview from "@/features/CenterOverview/CenterOverview";
+import CenterInfoCard from "@/features/CenterOverview/CenterInfoCard";
+import { CallIcon } from "@/assets/icons";
+const mockCenterData: CenterOverviewType = {
+  centerName: "남동구 노인 이동 센터",
+  centerTel: "032-742-9900",
+  centerAddr: "인천시 남동구 구월1동",
+  registeredCars: 4,
+  estimatedRevenue: "₩ 182,000",
+};
+
+describe("CenterOverview 컴포넌트", () => {
+  it("props로 전달받은 센터명을 화면에 렌더링한다.", () => {
+    render(<CenterOverview {...mockCenterData} />);
+    expect(screen.getByText("남동구 노인 이동 센터")).toBeInTheDocument();
+  });
+});
+
+describe("CenterInfoCard 컴포넌트", () => {
+  it("props로 전달받은 데이터를 각각의 역할에 맞게 렌더링한다.", () => {
+    render(
+      <CenterInfoCard
+        icon={<CallIcon />}
+        label="전화번호"
+        content="032-742-9900"
+      />,
+    );
+    expect(screen.getByText("전화번호")).toBeInTheDocument();
+    expect(screen.getByText("032-742-9900")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/features/CenterOverview/CenterOverview.tsx
+++ b/frontend/src/features/CenterOverview/CenterOverview.tsx
@@ -39,9 +39,9 @@ const CenterOverview = ({
     <div css={OverviewContainer}>
       <header css={OverviewHeader}>{centerName}</header>
       <div css={OverviewBody}>
-        {infoCardData.map((card, idx) => (
+        {infoCardData.map((card) => (
           <CenterInfoCard
-            key={idx}
+            key={`${card.label}-${card.content}`}
             icon={card.icon}
             label={card.label}
             content={card.content}

--- a/frontend/src/features/CenterOverview/CenterOverview.tsx
+++ b/frontend/src/features/CenterOverview/CenterOverview.tsx
@@ -1,0 +1,78 @@
+import { css } from "@emotion/react";
+import { theme } from "@/styles/themes.style";
+import type { CenterOverviewType } from "@/features/CenterOverview/CenterOverview.type";
+import CenterInfoCard from "@/features/CenterOverview/CenterInfoCard";
+import { CallIcon, CarIcon, LocationIcon, PayIcon } from "@/assets/icons";
+import type { CenterInfoCardProps } from "@/features/CenterOverview/CenterInfoCard";
+const { color, typography, borderRadius } = theme;
+
+const CenterOverview = ({
+  centerName,
+  centerTel,
+  centerAddr,
+  registeredCars,
+  estimatedRevenue,
+}: CenterOverviewType) => {
+  const infoCardData: CenterInfoCardProps[] = [
+    {
+      icon: <CallIcon fill={color.GrayScale.gray5} />,
+      label: "전화번호",
+      content: centerTel,
+    },
+    {
+      icon: <LocationIcon fill={color.GrayScale.gray5} />,
+      label: "센터 주소",
+      content: centerAddr,
+    },
+    {
+      icon: <CarIcon fill={color.GrayScale.gray5} />,
+      label: "등록 차량",
+      content: `${registeredCars} 대`,
+    },
+    {
+      icon: <PayIcon fill={color.GrayScale.gray5} />,
+      label: "예상 수익",
+      content: estimatedRevenue,
+    },
+  ];
+  return (
+    <div css={OverviewContainer}>
+      <header css={OverviewHeader}>{centerName}</header>
+      <div css={OverviewBody}>
+        {infoCardData.map((card, idx) => (
+          <CenterInfoCard
+            key={idx}
+            icon={card.icon}
+            label={card.label}
+            content={card.content}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default CenterOverview;
+
+const OverviewContainer = css`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 20px;
+  align-self: stretch;
+`;
+
+const OverviewHeader = css`
+  font: ${typography.Heading.h3_semi};
+  color: ${color.GrayScale.black};
+`;
+
+const OverviewBody = css`
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  background-color: ${color.GrayScale.gray1};
+  border-radius: ${borderRadius.Medium};
+  border: 1px solid ${color.GrayScale.gray3};
+`;

--- a/frontend/src/features/CenterOverview/CenterOverview.type.ts
+++ b/frontend/src/features/CenterOverview/CenterOverview.type.ts
@@ -1,0 +1,7 @@
+export type CenterOverviewType = {
+  centerName: string;
+  centerTel: string;
+  centerAddr: string;
+  registeredCars: number;
+  estimatedRevenue: string;
+};

--- a/frontend/src/layouts/AdminLayout.tsx
+++ b/frontend/src/layouts/AdminLayout.tsx
@@ -1,13 +1,21 @@
 import Header from "@/components/layouts/Header";
 import { Outlet } from "react-router";
-
+import { css } from "@emotion/react";
 const AdminLayout = () => {
   return (
     <div>
       <Header type="ADMIN" hasTab={true} />
-      <Outlet />
+      <div css={ContentContainer}>
+        <Outlet />
+      </div>
     </div>
   );
 };
 
 export default AdminLayout;
+
+const ContentContainer = css`
+  position: relative;
+  height: calc(100dvh - 72px);
+  top: 72px;
+`;

--- a/frontend/src/pages/admin/centers/CenterDetailPage.tsx
+++ b/frontend/src/pages/admin/centers/CenterDetailPage.tsx
@@ -1,5 +1,29 @@
+import CenterOverview from "@/features/CenterOverview/CenterOverview";
+import type { CenterOverviewType } from "@/features/CenterOverview/CenterOverview.type";
+import { css } from "@emotion/react";
+const mockCenterData: CenterOverviewType = {
+  centerName: "남동구 노인 이동 센터",
+  centerTel: "032-742-9900",
+  centerAddr: "인천시 남동구 구월1동",
+  registeredCars: 4,
+  estimatedRevenue: "₩ 182,000",
+};
+
 const CenterDetailPage = () => {
-  return <>CenterDetail</>;
+  return (
+    <div css={PageContainer}>
+      <CenterOverview {...mockCenterData} />
+    </div>
+  );
 };
 
 export default CenterDetailPage;
+
+const PageContainer = css`
+  width: 100vw;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 60px;
+  padding: 40px;
+`;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Close #105 

## 📝 기능 설명
(관리자)센터 상세 페이지 / (센터) 차량 관리 페이지 에 들어가는 센터 상세 정보 컴포넌트를 구현하였습니다.

## 🛠 작업 사항
`- CenterInfoCard.tsx`: icon, label, content를 받아 카드를 렌더링합니다.
`- CenterOverview.tsx`: 센터명, 카드에 들어갈 정보들을 받아 Overview Section을 렌더링합니다.

## ✅ 작업 항목
- [x] props로 받은 센터 정보를 렌더링
- [x] 센터 이름 (title)
- [x] 전화번호 / 위치 / 등록 차량 / 주간 수입 카드를 재사용하기 쉽게 구현
- [x] 테스트 주도 개발 방식 적용

## 📎 참고 자료
컴포넌트 단위로 잘게 PR을 쪼개려 했는데, 검토 후 병합까지 시간이 걸릴 것 같아 퍼블리싱 단계에서 작은 단위는 한 브랜치에서 작업 후 페이지 단위로 올려도 괜찮을까요 ??

- 화면
<img width="1249" height="782" alt="스크린샷 2025-08-07 오전 11 02 59" src="https://github.com/user-attachments/assets/07f1cd64-5f4f-423b-b141-4495d7702d7c" />

- 테스트 결과
<img width="771" height="216" alt="스크린샷 2025-08-07 오전 11 03 32" src="https://github.com/user-attachments/assets/0d3b22f6-e8bd-472b-adb8-95bb5a0ac719" />

