### PR TITLE
[ Feat/#110 ] 차량 리스트: `GET /api/car/list?center_id=`

### DIFF
--- a/backend/src/main/generated/hyfive/gachita/book/QBook.java
+++ b/backend/src/main/generated/hyfive/gachita/book/QBook.java
@@ -1,0 +1,78 @@
+package hyfive.gachita.book;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QBook is a Querydsl query type for Book
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QBook extends EntityPathBase<Book> {
+
+    private static final long serialVersionUID = -173036212L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QBook book = new QBook("book");
+
+    public final StringPath bookName = createString("bookName");
+
+    public final EnumPath<BookStatus> bookStatus = createEnum("bookStatus", BookStatus.class);
+
+    public final StringPath bookTel = createString("bookTel");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final TimePath<java.time.LocalTime> deadline = createTime("deadline", java.time.LocalTime.class);
+
+    public final StringPath endAddr = createString("endAddr");
+
+    public final NumberPath<Double> endLat = createNumber("endLat", Double.class);
+
+    public final NumberPath<Double> endLng = createNumber("endLng", Double.class);
+
+    public final DatePath<java.time.LocalDate> hospitalDate = createDate("hospitalDate", java.time.LocalDate.class);
+
+    public final TimePath<java.time.LocalTime> hospitalTime = createTime("hospitalTime", java.time.LocalTime.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final hyfive.gachita.path.QPath path;
+
+    public final StringPath startAddr = createString("startAddr");
+
+    public final NumberPath<Double> startLat = createNumber("startLat", Double.class);
+
+    public final NumberPath<Double> startLng = createNumber("startLng", Double.class);
+
+    public final BooleanPath walker = createBoolean("walker");
+
+    public QBook(String variable) {
+        this(Book.class, forVariable(variable), INITS);
+    }
+
+    public QBook(com.querydsl.core.types.Path<? extends Book> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QBook(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QBook(PathMetadata metadata, PathInits inits) {
+        this(Book.class, metadata, inits);
+    }
+
+    public QBook(Class<? extends Book> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.path = inits.isInitialized("path") ? new hyfive.gachita.path.QPath(forProperty("path"), inits.get("path")) : null;
+    }
+
+}
+

--- a/backend/src/main/generated/hyfive/gachita/car/QCar.java
+++ b/backend/src/main/generated/hyfive/gachita/car/QCar.java
@@ -1,0 +1,65 @@
+package hyfive.gachita.car;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QCar is a Querydsl query type for Car
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QCar extends EntityPathBase<Car> {
+
+    private static final long serialVersionUID = 201456760L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QCar car = new QCar("car");
+
+    public final NumberPath<Integer> capacity = createNumber("capacity", Integer.class);
+
+    public final StringPath carImage = createString("carImage");
+
+    public final StringPath carNumber = createString("carNumber");
+
+    public final hyfive.gachita.center.QCenter center;
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final EnumPath<DelYn> delYn = createEnum("delYn", DelYn.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final BooleanPath lowFloor = createBoolean("lowFloor");
+
+    public final StringPath modelName = createString("modelName");
+
+    public QCar(String variable) {
+        this(Car.class, forVariable(variable), INITS);
+    }
+
+    public QCar(Path<? extends Car> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QCar(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QCar(PathMetadata metadata, PathInits inits) {
+        this(Car.class, metadata, inits);
+    }
+
+    public QCar(Class<? extends Car> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.center = inits.isInitialized("center") ? new hyfive.gachita.center.QCenter(forProperty("center")) : null;
+    }
+
+}
+

--- a/backend/src/main/generated/hyfive/gachita/center/QCenter.java
+++ b/backend/src/main/generated/hyfive/gachita/center/QCenter.java
@@ -1,0 +1,52 @@
+package hyfive.gachita.center;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QCenter is a Querydsl query type for Center
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QCenter extends EntityPathBase<Center> {
+
+    private static final long serialVersionUID = 1321480076L;
+
+    public static final QCenter center = new QCenter("center");
+
+    public final ListPath<hyfive.gachita.car.Car, hyfive.gachita.car.QCar> carList = this.<hyfive.gachita.car.Car, hyfive.gachita.car.QCar>createList("carList", hyfive.gachita.car.Car.class, hyfive.gachita.car.QCar.class, PathInits.DIRECT2);
+
+    public final StringPath centerAddr = createString("centerAddr");
+
+    public final StringPath centerName = createString("centerName");
+
+    public final StringPath centerTel = createString("centerTel");
+
+    public final DateTimePath<java.time.LocalDateTime> createdAt = createDateTime("createdAt", java.time.LocalDateTime.class);
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final NumberPath<Double> lat = createNumber("lat", Double.class);
+
+    public final NumberPath<Double> lng = createNumber("lng", Double.class);
+
+    public QCenter(String variable) {
+        super(Center.class, forVariable(variable));
+    }
+
+    public QCenter(Path<? extends Center> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QCenter(PathMetadata metadata) {
+        super(Center.class, metadata);
+    }
+
+}
+

--- a/backend/src/main/generated/hyfive/gachita/node/QNode.java
+++ b/backend/src/main/generated/hyfive/gachita/node/QNode.java
@@ -1,0 +1,61 @@
+package hyfive.gachita.node;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QNode is a Querydsl query type for Node
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QNode extends EntityPathBase<Node> {
+
+    private static final long serialVersionUID = -1731676948L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QNode node = new QNode("node");
+
+    public final hyfive.gachita.book.QBook book;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final NumberPath<Double> lat = createNumber("lat", Double.class);
+
+    public final NumberPath<Double> lng = createNumber("lng", Double.class);
+
+    public final hyfive.gachita.path.QPath path;
+
+    public final TimePath<java.time.LocalTime> time = createTime("time", java.time.LocalTime.class);
+
+    public final EnumPath<NodeType> type = createEnum("type", NodeType.class);
+
+    public QNode(String variable) {
+        this(Node.class, forVariable(variable), INITS);
+    }
+
+    public QNode(com.querydsl.core.types.Path<? extends Node> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QNode(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QNode(PathMetadata metadata, PathInits inits) {
+        this(Node.class, metadata, inits);
+    }
+
+    public QNode(Class<? extends Node> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.book = inits.isInitialized("book") ? new hyfive.gachita.book.QBook(forProperty("book"), inits.get("book")) : null;
+        this.path = inits.isInitialized("path") ? new hyfive.gachita.path.QPath(forProperty("path"), inits.get("path")) : null;
+    }
+
+}
+

--- a/backend/src/main/generated/hyfive/gachita/path/QPath.java
+++ b/backend/src/main/generated/hyfive/gachita/path/QPath.java
@@ -1,0 +1,70 @@
+package hyfive.gachita.path;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QPath is a Querydsl query type for Path
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QPath extends EntityPathBase<Path> {
+
+    private static final long serialVersionUID = 1719931596L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QPath path = new QPath("path");
+
+    public final hyfive.gachita.car.QCar car;
+
+    public final DatePath<java.time.LocalDate> driveDate = createDate("driveDate", java.time.LocalDate.class);
+
+    public final EnumPath<DriveStatus> driveStatus = createEnum("driveStatus", DriveStatus.class);
+
+    public final StringPath endAddr = createString("endAddr");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final TimePath<java.time.LocalTime> maybeEndTime = createTime("maybeEndTime", java.time.LocalTime.class);
+
+    public final TimePath<java.time.LocalTime> maybeStartTime = createTime("maybeStartTime", java.time.LocalTime.class);
+
+    public final ListPath<hyfive.gachita.node.Node, hyfive.gachita.node.QNode> nodeList = this.<hyfive.gachita.node.Node, hyfive.gachita.node.QNode>createList("nodeList", hyfive.gachita.node.Node.class, hyfive.gachita.node.QNode.class, PathInits.DIRECT2);
+
+    public final TimePath<java.time.LocalTime> realEndTime = createTime("realEndTime", java.time.LocalTime.class);
+
+    public final TimePath<java.time.LocalTime> realStartTime = createTime("realStartTime", java.time.LocalTime.class);
+
+    public final StringPath startAddr = createString("startAddr");
+
+    public final NumberPath<Integer> userCount = createNumber("userCount", Integer.class);
+
+    public QPath(String variable) {
+        this(Path.class, forVariable(variable), INITS);
+    }
+
+    public QPath(com.querydsl.core.types.Path<? extends Path> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QPath(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QPath(PathMetadata metadata, PathInits inits) {
+        this(Path.class, metadata, inits);
+    }
+
+    public QPath(Class<? extends Path> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.car = inits.isInitialized("car") ? new hyfive.gachita.car.QCar(forProperty("car"), inits.get("car")) : null;
+    }
+
+}
+

--- a/backend/src/main/generated/hyfive/gachita/pay/QPay.java
+++ b/backend/src/main/generated/hyfive/gachita/pay/QPay.java
@@ -1,0 +1,55 @@
+package hyfive.gachita.pay;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QPay is a Querydsl query type for Pay
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QPay extends EntityPathBase<Pay> {
+
+    private static final long serialVersionUID = -1139420128L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QPay pay = new QPay("pay");
+
+    public final NumberPath<Integer> amount = createNumber("amount", Integer.class);
+
+    public final hyfive.gachita.center.QCenter center;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final DatePath<java.time.LocalDate> payDate = createDate("payDate", java.time.LocalDate.class);
+
+    public QPay(String variable) {
+        this(Pay.class, forVariable(variable), INITS);
+    }
+
+    public QPay(Path<? extends Pay> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QPay(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QPay(PathMetadata metadata, PathInits inits) {
+        this(Pay.class, metadata, inits);
+    }
+
+    public QPay(Class<? extends Pay> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.center = inits.isInitialized("center") ? new hyfive.gachita.center.QCenter(forProperty("center")) : null;
+    }
+
+}
+

--- a/backend/src/main/generated/hyfive/gachita/rental/QRental.java
+++ b/backend/src/main/generated/hyfive/gachita/rental/QRental.java
@@ -1,0 +1,57 @@
+package hyfive.gachita.rental;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+import com.querydsl.core.types.dsl.PathInits;
+
+
+/**
+ * QRental is a Querydsl query type for Rental
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QRental extends EntityPathBase<Rental> {
+
+    private static final long serialVersionUID = -1582204756L;
+
+    private static final PathInits INITS = PathInits.DIRECT2;
+
+    public static final QRental rental = new QRental("rental");
+
+    public final hyfive.gachita.car.QCar car;
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final DatePath<java.time.LocalDate> rentalDate = createDate("rentalDate", java.time.LocalDate.class);
+
+    public final TimePath<java.time.LocalTime> rentalEndTime = createTime("rentalEndTime", java.time.LocalTime.class);
+
+    public final TimePath<java.time.LocalTime> rentalStartTime = createTime("rentalStartTime", java.time.LocalTime.class);
+
+    public QRental(String variable) {
+        this(Rental.class, forVariable(variable), INITS);
+    }
+
+    public QRental(Path<? extends Rental> path) {
+        this(path.getType(), path.getMetadata(), PathInits.getFor(path.getMetadata(), INITS));
+    }
+
+    public QRental(PathMetadata metadata) {
+        this(metadata, PathInits.getFor(metadata, INITS));
+    }
+
+    public QRental(PathMetadata metadata, PathInits inits) {
+        this(Rental.class, metadata, inits);
+    }
+
+    public QRental(Class<? extends Rental> type, PathMetadata metadata, PathInits inits) {
+        super(type, metadata, inits);
+        this.car = inits.isInitialized("car") ? new hyfive.gachita.car.QCar(forProperty("car"), inits.get("car")) : null;
+    }
+
+}
+

--- a/backend/src/main/generated/hyfive/gachita/test/QTest.java
+++ b/backend/src/main/generated/hyfive/gachita/test/QTest.java
@@ -1,0 +1,41 @@
+package hyfive.gachita.test;
+
+import static com.querydsl.core.types.PathMetadataFactory.*;
+
+import com.querydsl.core.types.dsl.*;
+
+import com.querydsl.core.types.PathMetadata;
+import javax.annotation.processing.Generated;
+import com.querydsl.core.types.Path;
+
+
+/**
+ * QTest is a Querydsl query type for Test
+ */
+@Generated("com.querydsl.codegen.DefaultEntitySerializer")
+public class QTest extends EntityPathBase<Test> {
+
+    private static final long serialVersionUID = 917524204L;
+
+    public static final QTest test = new QTest("test");
+
+    public final StringPath content = createString("content");
+
+    public final NumberPath<Long> id = createNumber("id", Long.class);
+
+    public final StringPath title = createString("title");
+
+    public QTest(String variable) {
+        super(Test.class, forVariable(variable));
+    }
+
+    public QTest(Path<? extends Test> path) {
+        super(path.getType(), path.getMetadata());
+    }
+
+    public QTest(PathMetadata metadata) {
+        super(Test.class, metadata);
+    }
+
+}
+

--- a/backend/src/main/java/hyfive/gachita/car/Car.java
+++ b/backend/src/main/java/hyfive/gachita/car/Car.java
@@ -53,5 +53,13 @@ public class Car {
     @Enumerated(EnumType.STRING)
     @Column(name = "del_yn", nullable = false, columnDefinition = "VARCHAR(50)")
     private DelYn delYn = DelYn.N;
+
+    public void update(String modelName, String carNumber, int capacity, Boolean lowFloor, String carImage) {
+        this.modelName = modelName;
+        this.carNumber = carNumber;
+        this.capacity = capacity;
+        this.lowFloor = lowFloor;
+        this.carImage = carImage;
+    }
 }
 

--- a/backend/src/main/java/hyfive/gachita/car/CarController.java
+++ b/backend/src/main/java/hyfive/gachita/car/CarController.java
@@ -2,8 +2,10 @@ package hyfive.gachita.car;
 
 import hyfive.gachita.car.dto.CarRes;
 import hyfive.gachita.car.dto.CreateCarReq;
+import hyfive.gachita.car.dto.UpdateCarReq;
 import hyfive.gachita.common.response.BaseResponse;
 import hyfive.gachita.docs.CarDocs;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
@@ -19,5 +21,13 @@ public class CarController implements CarDocs {
     public BaseResponse<CarRes> createCar(@ModelAttribute @Validated CreateCarReq createCarReq) {
         Car createCar = carService.createCar(createCarReq);
         return BaseResponse.success(CarRes.from(createCar));
+    }
+
+    @PatchMapping("/{id}")
+    public BaseResponse<CarRes> updateCar(
+            @Validated @PathVariable("id") @NotNull Long id,
+            @ModelAttribute @Validated UpdateCarReq updateCarReq) {
+        Car updateCar = carService.updateCar(id, updateCarReq);
+        return BaseResponse.success(CarRes.from(updateCar));
     }
 }

--- a/backend/src/main/java/hyfive/gachita/car/CarController.java
+++ b/backend/src/main/java/hyfive/gachita/car/CarController.java
@@ -24,7 +24,7 @@ public class CarController implements CarDocs {
         return BaseResponse.success(CarRes.from(createCar));
     }
 
-    @PatchMapping("/{id}")
+    @PatchMapping(path = "/{id}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public BaseResponse<CarRes> updateCar(
             @PathVariable("id") @NotNull Long id,
             @ModelAttribute UpdateCarReq updateCarReq) {

--- a/backend/src/main/java/hyfive/gachita/car/CarController.java
+++ b/backend/src/main/java/hyfive/gachita/car/CarController.java
@@ -26,8 +26,8 @@ public class CarController implements CarDocs {
 
     @PatchMapping("/{id}")
     public BaseResponse<CarRes> updateCar(
-            @Validated @PathVariable("id") @NotNull Long id,
-            @ModelAttribute @Validated UpdateCarReq updateCarReq) {
+            @PathVariable("id") @NotNull Long id,
+            @ModelAttribute UpdateCarReq updateCarReq) {
         Car updateCar = carService.updateCar(id, updateCarReq);
         return BaseResponse.success(CarRes.from(updateCar));
     }

--- a/backend/src/main/java/hyfive/gachita/car/CarController.java
+++ b/backend/src/main/java/hyfive/gachita/car/CarController.java
@@ -31,4 +31,10 @@ public class CarController implements CarDocs {
         Car updateCar = carService.updateCar(id, updateCarReq);
         return BaseResponse.success(CarRes.from(updateCar));
     }
+
+    @GetMapping("/{id}")
+    public BaseResponse<CarRes> getCarById(@PathVariable("id") @NotNull Long id) {
+        Car getCar = carService.getCar(id);
+        return BaseResponse.success(CarRes.from(getCar));
+    }
 }

--- a/backend/src/main/java/hyfive/gachita/car/CarController.java
+++ b/backend/src/main/java/hyfive/gachita/car/CarController.java
@@ -1,8 +1,10 @@
 package hyfive.gachita.car;
 
+import hyfive.gachita.car.dto.CarListRes;
 import hyfive.gachita.car.dto.CarRes;
 import hyfive.gachita.car.dto.CreateCarReq;
 import hyfive.gachita.car.dto.UpdateCarReq;
+import hyfive.gachita.common.dto.ListRes;
 import hyfive.gachita.common.response.BaseResponse;
 import hyfive.gachita.docs.CarDocs;
 import jakarta.validation.constraints.NotNull;
@@ -36,5 +38,12 @@ public class CarController implements CarDocs {
     public BaseResponse<CarRes> getCar(@PathVariable("id") @NotNull Long id) {
         Car getCar = carService.getCar(id);
         return BaseResponse.success(CarRes.from(getCar));
+    }
+
+    @GetMapping("/list")
+    public BaseResponse<ListRes<CarListRes>> getCarList(
+            @RequestParam(name = "center_id") Long centerId
+    ) {
+        return BaseResponse.success(carService.getCarList(centerId));
     }
 }

--- a/backend/src/main/java/hyfive/gachita/car/CarController.java
+++ b/backend/src/main/java/hyfive/gachita/car/CarController.java
@@ -33,7 +33,7 @@ public class CarController implements CarDocs {
     }
 
     @GetMapping("/{id}")
-    public BaseResponse<CarRes> getCarById(@PathVariable("id") @NotNull Long id) {
+    public BaseResponse<CarRes> getCar(@PathVariable("id") @NotNull Long id) {
         Car getCar = carService.getCar(id);
         return BaseResponse.success(CarRes.from(getCar));
     }

--- a/backend/src/main/java/hyfive/gachita/car/CarRepository.java
+++ b/backend/src/main/java/hyfive/gachita/car/CarRepository.java
@@ -9,4 +9,6 @@ public interface CarRepository extends JpaRepository<Car, Long> {
 
     boolean existsByCarNumberAndDelYn(String carNumber, DelYn delYn);
 
+    boolean existsByIdNotAndCarNumberAndDelYn(Long id, String carNumber, DelYn delYn);
+
 }

--- a/backend/src/main/java/hyfive/gachita/car/CarService.java
+++ b/backend/src/main/java/hyfive/gachita/car/CarService.java
@@ -71,4 +71,10 @@ public class CarService {
 
         return car;
     }
+
+    public Car getCar(Long id) {
+        Car car = carRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NO_EXIST_VALUE, "DB에 차량 데이터가 존재하지 않습니다."));
+        return car;
+    }
 }

--- a/backend/src/main/java/hyfive/gachita/car/CarService.java
+++ b/backend/src/main/java/hyfive/gachita/car/CarService.java
@@ -30,7 +30,7 @@ public class CarService {
         String normalizedCarNumber = getValidatedCarNumber(createCarReq.carNumber());
 
         // TODO : 이미지 저장 service 개발 필요
-        String imgUrl = "test";
+        String imageUrl = "test";
 
         // 엔티티 생성
         Car car = Car.builder()
@@ -39,7 +39,7 @@ public class CarService {
                 .carNumber(normalizedCarNumber)
                 .capacity(createCarReq.capacity())
                 .lowFloor(createCarReq.lowFloor())
-                .carImage(imgUrl)
+                .carImage(imageUrl)
                 .build();
 
         return carRepository.save(car);

--- a/backend/src/main/java/hyfive/gachita/car/CarService.java
+++ b/backend/src/main/java/hyfive/gachita/car/CarService.java
@@ -1,14 +1,19 @@
 package hyfive.gachita.car;
 
+import hyfive.gachita.car.dto.CarListRes;
 import hyfive.gachita.car.dto.CreateCarReq;
 import hyfive.gachita.car.dto.UpdateCarReq;
+import hyfive.gachita.car.repository.CarRepository;
 import hyfive.gachita.center.Center;
 import hyfive.gachita.center.CenterRepository;
+import hyfive.gachita.common.dto.ListRes;
 import hyfive.gachita.common.response.BusinessException;
 import hyfive.gachita.common.response.ErrorCode;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 import static hyfive.gachita.common.util.CarNumberFormatter.normalize;
 
@@ -76,5 +81,19 @@ public class CarService {
         Car car = carRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NO_EXIST_VALUE, "DB에 차량 데이터가 존재하지 않습니다."));
         return car;
+    }
+
+    public ListRes<CarListRes> getCarList(Long centerId) {
+        centerRepository.findById(centerId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NO_EXIST_VALUE, "DB에 센터 데이터가 존재하지 않습니다."));
+
+        List<CarListRes> listResult = carRepository.searchCarListByCondition(centerId);
+
+        return ListRes.<CarListRes>builder()
+                .items(listResult)
+                .currentPageNum(1)
+                .totalPageNum(1)
+                .totalItemNum(listResult.size())
+                .build();
     }
 }

--- a/backend/src/main/java/hyfive/gachita/car/CarService.java
+++ b/backend/src/main/java/hyfive/gachita/car/CarService.java
@@ -1,10 +1,12 @@
 package hyfive.gachita.car;
 
 import hyfive.gachita.car.dto.CreateCarReq;
+import hyfive.gachita.car.dto.UpdateCarReq;
 import hyfive.gachita.center.Center;
 import hyfive.gachita.center.CenterRepository;
 import hyfive.gachita.common.response.BusinessException;
 import hyfive.gachita.common.response.ErrorCode;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -32,5 +34,26 @@ public class CarService {
                 .build();
 
         return carRepository.save(car);
+    }
+
+    @Transactional
+    public Car updateCar(Long id, UpdateCarReq updateCarReq) {
+        Car car = carRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NO_EXIST_VALUE, "DB에 차량 데이터가 존재하지 않습니다."));
+
+        // TODO : 이미지 저장 service 개발 필요 - 기존 사진 덮어 쓰기
+        String imageUrl = "test_change";
+
+
+        // 3. 엔티티 필드 수정 (Dirty Checking)
+        car.update(
+                updateCarReq.modelName(),
+                updateCarReq.carNumber(),
+                updateCarReq.capacity(),
+                updateCarReq.lowFloor(),
+                imageUrl
+        );
+
+        return car;
     }
 }

--- a/backend/src/main/java/hyfive/gachita/car/CarService.java
+++ b/backend/src/main/java/hyfive/gachita/car/CarService.java
@@ -27,10 +27,7 @@ public class CarService {
             throw new BusinessException(ErrorCode.MAX_CAR_COUNT_EXCEEDED);
         }
 
-        String normalizedCarNumber = normalize(createCarReq.carNumber());
-        if (carRepository.existsByCarNumberAndDelYn(normalizedCarNumber, DelYn.N)) {
-            throw new BusinessException(ErrorCode.DUPLICATE_CAR_NUMBER);
-        }
+        String normalizedCarNumber = getValidatedCarNumber(createCarReq.carNumber());
 
         // TODO : 이미지 저장 service 개발 필요
         String imgUrl = "test";
@@ -53,19 +50,28 @@ public class CarService {
         Car car = carRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NO_EXIST_VALUE, "DB에 차량 데이터가 존재하지 않습니다."));
 
+        String normalizedCarNumber = getValidatedCarNumber(updateCarReq.carNumber());
+
         // TODO : 이미지 저장 service 개발 필요 - 기존 사진 덮어 쓰기
         String imageUrl = "test_change";
 
-
-        // 3. 엔티티 필드 수정 (Dirty Checking)
         car.update(
                 updateCarReq.modelName(),
-                updateCarReq.carNumber(),
+                normalizedCarNumber,
                 updateCarReq.capacity(),
                 updateCarReq.lowFloor(),
                 imageUrl
         );
 
         return car;
+    }
+
+    private String getValidatedCarNumber(String carNumber) {
+        String normalizedCarNumber = normalize(carNumber);
+        if (carRepository.existsByCarNumberAndDelYn(normalizedCarNumber, DelYn.N)) {
+            throw new BusinessException(ErrorCode.DUPLICATE_CAR_NUMBER);
+        } else {
+            return normalizedCarNumber;
+        }
     }
 }

--- a/backend/src/main/java/hyfive/gachita/car/CarService.java
+++ b/backend/src/main/java/hyfive/gachita/car/CarService.java
@@ -27,7 +27,10 @@ public class CarService {
             throw new BusinessException(ErrorCode.MAX_CAR_COUNT_EXCEEDED);
         }
 
-        String normalizedCarNumber = getValidatedCarNumber(createCarReq.carNumber());
+        String normalizedCarNumber = normalize(createCarReq.carNumber());
+        if (carRepository.existsByCarNumberAndDelYn(normalizedCarNumber, DelYn.N)) {
+            throw new BusinessException(ErrorCode.DUPLICATE_CAR_NUMBER);
+        }
 
         // TODO : 이미지 저장 service 개발 필요
         String imageUrl = "test";
@@ -50,7 +53,10 @@ public class CarService {
         Car car = carRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NO_EXIST_VALUE, "DB에 차량 데이터가 존재하지 않습니다."));
 
-        String normalizedCarNumber = getValidatedCarNumber(updateCarReq.carNumber());
+        String normalizedCarNumber = normalize(updateCarReq.carNumber());
+        if (carRepository.existsByIdNotAndCarNumberAndDelYn(id, normalizedCarNumber, DelYn.N)) {
+            throw new BusinessException(ErrorCode.DUPLICATE_CAR_NUMBER);
+        }
 
         // TODO : 이미지 저장 service 개발 필요 - 기존 사진 덮어 쓰기
         String imageUrl = "test_change";
@@ -64,14 +70,5 @@ public class CarService {
         );
 
         return car;
-    }
-
-    private String getValidatedCarNumber(String carNumber) {
-        String normalizedCarNumber = normalize(carNumber);
-        if (carRepository.existsByCarNumberAndDelYn(normalizedCarNumber, DelYn.N)) {
-            throw new BusinessException(ErrorCode.DUPLICATE_CAR_NUMBER);
-        } else {
-            return normalizedCarNumber;
-        }
     }
 }

--- a/backend/src/main/java/hyfive/gachita/car/dto/CarListRes.java
+++ b/backend/src/main/java/hyfive/gachita/car/dto/CarListRes.java
@@ -1,0 +1,43 @@
+package hyfive.gachita.car.dto;
+
+import hyfive.gachita.car.Car;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import static hyfive.gachita.common.util.CarNumberFormatter.format;
+
+public record CarListRes(
+        @Schema(description = "차량 ID", example = "1")
+        Long id,
+
+        @Schema(description = "차량 모델명", example = "기아 레이")
+        String modelName,
+
+        @Schema(description = "차량 번호", example = "12가 3456")
+        String carNumber,
+
+        @Schema(description = "탑승 가능 인원 수", example = "3")
+        int capacity,
+
+        @Schema(description = "저상 차량 여부", example = "false")
+        Boolean lowFloor,
+
+        // TODO : carImage example 추가
+        @Schema(description = "차량 이미지 url", example = "(차후 추가 예정)")
+        String carImage,
+
+        @Schema(description = "차량 운행 상태", example = "false")
+        Boolean running
+) {
+    public static CarListRes from(Car car, Boolean running) {
+        return new CarListRes(
+                car.getId(),
+                car.getModelName(),
+                format(car.getCarNumber()),
+                car.getCapacity(),
+                car.getLowFloor(),
+                car.getCarImage(),
+                running
+        );
+    }
+}
+

--- a/backend/src/main/java/hyfive/gachita/car/dto/CreateCarReq.java
+++ b/backend/src/main/java/hyfive/gachita/car/dto/CreateCarReq.java
@@ -31,6 +31,6 @@ public record CreateCarReq(
 
         @NotNull
         @Schema(description = "차량 이미지 파일", example = "이미지는 최대 10MB까지 첨부 가능합니다")
-        MultipartFile imgFile
+        MultipartFile imageFile
 ) {}
 

--- a/backend/src/main/java/hyfive/gachita/car/dto/UpdateCarReq.java
+++ b/backend/src/main/java/hyfive/gachita/car/dto/UpdateCarReq.java
@@ -25,7 +25,7 @@ public record UpdateCarReq(
         Boolean lowFloor,
 
         @NotNull
-        @Schema(description = "차량 이미지 URL", example = "이미지는 최대 10MB까지 첨부 가능합니다")
+        @Schema(description = "차량 이미지 파일", example = "이미지는 최대 10MB까지 첨부 가능합니다")
         MultipartFile imgFile
 ) {}
 

--- a/backend/src/main/java/hyfive/gachita/car/dto/UpdateCarReq.java
+++ b/backend/src/main/java/hyfive/gachita/car/dto/UpdateCarReq.java
@@ -1,0 +1,31 @@
+package hyfive.gachita.car.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@Schema(description = "차량 수정 요청 DTO")
+public record UpdateCarReq(
+        @NotBlank
+        @Schema(description = "차량 모델명", example = "기아 레이")
+        String modelName,
+
+        @NotBlank
+        @Pattern(regexp = "^[0-9가-힣\\s-]{1,20}$")
+        @Schema(description = "차량 번호", example = "12가 3456")
+        String carNumber,
+
+        @Min(1)
+        @Max(25)
+        @Schema(description = "탑승 가능 인원 수", example = "3")
+        int capacity,
+
+        @NotNull
+        @Schema(description = "저상 차량 여부", example = "false")
+        Boolean lowFloor,
+
+        @NotNull
+        @Schema(description = "차량 이미지 URL", example = "이미지는 최대 10MB까지 첨부 가능합니다")
+        MultipartFile imgFile
+) {}
+

--- a/backend/src/main/java/hyfive/gachita/car/dto/UpdateCarReq.java
+++ b/backend/src/main/java/hyfive/gachita/car/dto/UpdateCarReq.java
@@ -26,6 +26,6 @@ public record UpdateCarReq(
 
         @NotNull
         @Schema(description = "차량 이미지 파일", example = "이미지는 최대 10MB까지 첨부 가능합니다")
-        MultipartFile imgFile
+        MultipartFile imageFile
 ) {}
 

--- a/backend/src/main/java/hyfive/gachita/car/repository/CarRepository.java
+++ b/backend/src/main/java/hyfive/gachita/car/repository/CarRepository.java
@@ -1,9 +1,11 @@
-package hyfive.gachita.car;
+package hyfive.gachita.car.repository;
 
+import hyfive.gachita.car.Car;
+import hyfive.gachita.car.DelYn;
 import hyfive.gachita.center.Center;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CarRepository extends JpaRepository<Car, Long> {
+public interface CarRepository extends JpaRepository<Car, Long>, CustomCarRepository {
 
     long countByCenterAndDelYn(Center center, DelYn delYn);
 

--- a/backend/src/main/java/hyfive/gachita/car/repository/CustomCarRepository.java
+++ b/backend/src/main/java/hyfive/gachita/car/repository/CustomCarRepository.java
@@ -1,0 +1,9 @@
+package hyfive.gachita.car.repository;
+
+import hyfive.gachita.car.dto.CarListRes;
+
+import java.util.List;
+
+public interface CustomCarRepository {
+    List<CarListRes> searchCarListByCondition(Long centerId);
+}

--- a/backend/src/main/java/hyfive/gachita/car/repository/CustomCarRepositoryImpl.java
+++ b/backend/src/main/java/hyfive/gachita/car/repository/CustomCarRepositoryImpl.java
@@ -1,0 +1,68 @@
+package hyfive.gachita.car.repository;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.BooleanTemplate;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import hyfive.gachita.car.DelYn;
+import hyfive.gachita.car.dto.CarListRes;
+import hyfive.gachita.path.DriveStatus;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.List;
+
+import static hyfive.gachita.car.QCar.car;
+import static hyfive.gachita.path.QPath.path;
+
+@RequiredArgsConstructor
+public class CustomCarRepositoryImpl implements CustomCarRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<CarListRes> searchCarListByCondition(Long centerId) {
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+
+        List<Long> carIds = queryFactory
+                .select(car.id)
+                .from(car)
+                .where(
+                        car.center.id.eq(centerId),
+                        car.delYn.eq(DelYn.N)
+                )
+                .orderBy(car.createdAt.asc())
+                .fetch();
+
+        if (carIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        BooleanTemplate runningExpr = Expressions.booleanTemplate(
+                "sum(case when {0} = {1} then 1 else 0 end) > 0",
+                path.driveStatus,
+                DriveStatus.RUNNING
+        );
+
+        List<Tuple> carList = queryFactory
+                .select(car, runningExpr)
+                .from(car)
+                .leftJoin(path).on(
+                        path.car.id.eq(car.id)
+                                .and(path.driveDate.eq(today))
+                )
+                .where(car.id.in(carIds))
+                .groupBy(car.id)
+                .orderBy(car.createdAt.asc())
+                .fetch();
+
+        return carList.stream()
+                .map(tuple -> CarListRes.from(
+                        tuple.get(car),
+                        tuple.get(runningExpr)
+                ))
+                .toList();
+    }
+}

--- a/backend/src/main/java/hyfive/gachita/docs/CarDocs.java
+++ b/backend/src/main/java/hyfive/gachita/docs/CarDocs.java
@@ -1,8 +1,10 @@
 package hyfive.gachita.docs;
 
+import hyfive.gachita.car.dto.CarListRes;
 import hyfive.gachita.car.dto.CarRes;
 import hyfive.gachita.car.dto.CreateCarReq;
 import hyfive.gachita.car.dto.UpdateCarReq;
+import hyfive.gachita.common.dto.ListRes;
 import hyfive.gachita.common.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -13,6 +15,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "car", description = "차량 관련 API")
 public interface CarDocs {
@@ -116,5 +119,30 @@ public interface CarDocs {
     })
     BaseResponse<CarRes> getCar(
             @PathVariable("id") @NotNull Long id
+    );
+
+    @Operation(
+            summary = "센터별 차량 리스트 API",
+            description = "센터 ID를 받아 차량 리스트를 가져옵니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "1000",
+                    description = "차량 리스트 정보 조회 성공 시, 차량 리스트를 응답합니다.",
+                    content = @Content(schema = @Schema(implementation = CarRes.class))
+            ),
+            @ApiResponse(
+                    responseCode = "2000",
+                    description = "필드가 비어있거나 잘못된 형식으로 요청한 경우 발생",
+                    content = @Content()
+            ),
+            @ApiResponse(
+                    responseCode = "3001",
+                    description = "요청한 센터 ID가 DB에 존재하지 않는 경우 발생",
+                    content = @Content()
+            )
+    })
+    BaseResponse<ListRes<CarListRes>> getCarList(
+            @RequestParam(name = "center_id") Long centerId
     );
 }

--- a/backend/src/main/java/hyfive/gachita/docs/CarDocs.java
+++ b/backend/src/main/java/hyfive/gachita/docs/CarDocs.java
@@ -2,13 +2,16 @@ package hyfive.gachita.docs;
 
 import hyfive.gachita.car.dto.CarRes;
 import hyfive.gachita.car.dto.CreateCarReq;
+import hyfive.gachita.car.dto.UpdateCarReq;
 import hyfive.gachita.common.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "car", description = "차량 관련 API")
 public interface CarDocs {
@@ -21,7 +24,7 @@ public interface CarDocs {
             @ApiResponse(
                     responseCode = "1000",
                     description = "차량 생성 성공 시, 아이디와 차량 등록 시점의 데이터를 추가하여 응답",
-                    content = @Content()
+                    content = @Content(schema = @Schema(implementation = CarRes.class))
             ),
             @ApiResponse(
                     responseCode = "2000",
@@ -37,9 +40,55 @@ public interface CarDocs {
                     responseCode = "3005",
                     description = "첨부한 차량 이미지의 사이즈가 10MB를 초과했을 경우 발생",
                     content = @Content()
+            ),
+            @ApiResponse(
+                    responseCode = "4500",
+                    description = "차량을 초과 등록하려고 하는 경우 발생 (최대 6대)",
+                    content = @Content()
+            ),
+            @ApiResponse(
+                    responseCode = "4501",
+                    description = "중복된 차량 번호가 존재하는 경우 발생",
+                    content = @Content()
             )
     })
     BaseResponse<CarRes> createCar(
-            @Validated CreateCarReq createCarReq
+            @ModelAttribute CreateCarReq createCarReq
+    );
+
+    @Operation(
+            summary = "차량 정보 수정 API",
+            description = "차량 ID와 수정할 차량 정보를 받아 차량 정보를 업데이트합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "1000",
+                    description = "차량 정보 수정 성공 시, 수정된 차량 정보를 응답합니다.",
+                    content = @Content(schema = @Schema(implementation = CarRes.class))
+            ),
+            @ApiResponse(
+                    responseCode = "2000",
+                    description = "필드가 비어있거나 잘못된 body 형식으로 요청한 경우 발생",
+                    content = @Content()
+            ),
+            @ApiResponse(
+                    responseCode = "3001",
+                    description = "요청한 차량 ID가 DB에 존재하지 않는 경우 발생",
+                    content = @Content()
+            ),
+            @ApiResponse(
+                    responseCode = "3005",
+                    description = "첨부한 차량 이미지의 사이즈가 10MB를 초과했을 경우 발생",
+                    content = @Content()
+            ),
+            @ApiResponse(
+                    responseCode = "4501",
+                    description = "중복된 차량 번호가 존재하는 경우 발생",
+                    content = @Content()
+            )
+    })
+    BaseResponse<CarRes> updateCar(
+            @PathVariable("id") Long id,
+            @ModelAttribute UpdateCarReq updateCarReq
     );
 }

--- a/backend/src/main/java/hyfive/gachita/docs/CarDocs.java
+++ b/backend/src/main/java/hyfive/gachita/docs/CarDocs.java
@@ -92,4 +92,29 @@ public interface CarDocs {
             @PathVariable("id") @NotNull Long id,
             @ModelAttribute UpdateCarReq updateCarReq
     );
+
+    @Operation(
+            summary = "차량 상세 정보 API",
+            description = "차량 ID를 받아 차량 상세 정보를 가져옵니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "1000",
+                    description = "차량 상세 정보 조회 성공 시, 차량 정보를 응답합니다.",
+                    content = @Content(schema = @Schema(implementation = CarRes.class))
+            ),
+            @ApiResponse(
+                    responseCode = "2000",
+                    description = "필드가 비어있거나 잘못된 형식으로 요청한 경우 발생",
+                    content = @Content()
+            ),
+            @ApiResponse(
+                    responseCode = "3001",
+                    description = "요청한 차량 ID가 DB에 존재하지 않는 경우 발생",
+                    content = @Content()
+            )
+    })
+    BaseResponse<CarRes> getCar(
+            @PathVariable("id") @NotNull Long id
+    );
 }

--- a/backend/src/main/java/hyfive/gachita/docs/CarDocs.java
+++ b/backend/src/main/java/hyfive/gachita/docs/CarDocs.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotNull;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 
@@ -88,7 +89,7 @@ public interface CarDocs {
             )
     })
     BaseResponse<CarRes> updateCar(
-            @PathVariable("id") Long id,
+            @PathVariable("id") @NotNull Long id,
             @ModelAttribute UpdateCarReq updateCarReq
     );
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Close #110 

## 📝 기능 설명
center_id에 해당하는 차량 리스트를 조회하는 API

## 🛠 작업 사항

### 1. 차량 리스트 api 관련 작업
- CarCustomRepository, CarCustomRepositoryImpl를 신규 생성하여 queryDSL 적용
- CarListRes dto 생성
- `searchCarListByCondition()` 메서드 추가 (center_id에 해당하는 삭제되지 않은 모든 차량 조회)
- 리스트 호출 최적화 진행 (하단에 상세 내역 작성)

### 2. 리스트 호출 최적화 진행 
#### 1. 초기 방법
- 요약 : car, path join 후 center_id에 해당하는 차량 조회
- 문제점 : 
  - 요청받은 센터에 포함되지 않은 차량도 join 연산에 포함되어, 차후 car와 path가 많아질 경우 성능 저하 우려
  - QueryDSL에서 반환받은 데이터는 StringPath라서 CarListRes의 carNumber에 `CarNumberFormatter.format(String carNumber)` 적용 어려움. 
  - 차량 리스트는 전체 리스트 반환이라 Page가 불필요
```java
@Override
    public Page<CarListRes> searchCarPageByCondition(Long centerId, Pageable pageable) {
        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));

        BooleanTemplate runningExpr = Expressions.booleanTemplate(
                "sum(case when {0} = {1} then 1 else 0 end) > 0",
                path.driveStatus,
                DriveStatus.RUNNING
        );


        List<CarListRes> carList = queryFactory
                .select(Projections.constructor(
                        CarListRes.class,
                        car.id,
                        car.modelName,
                        car.carNumber,
                        car.capacity,
                        car.lowFloor,
                        car.carImage,
                        runningExpr
                ))
                .from(car)
                .leftJoin(path).on(
                        path.car.id.eq(car.id)
                                .and(path.driveDate.eq(today))
                )
                .where(
                        car.center.id.eq(centerId),
                        car.delYn.eq(DelYn.N)
                )
                .groupBy(car.id)
                .orderBy(car.createdAt.asc())
                .fetch();

        return new PageImpl<>(carList, pageable, carList.size());
    }
```

#### 2. 최적화 후
- 요약 : center_id에 해당하는 car 조회 후, path와 join 진행 
- 개선 방안 : 
  - 서브 쿼리로 요청받은 세넡에 포함된 carId 먼저 추출 후, path와 join 진행. center별 최대 등록 차량수는 6대라서 join 연산 감소.
  - Tuple로 List를 반환받은 후, stream()으로 `CarListRes.from(Car car, Boolean running)` 적용
  - Page<CarListRes> -> List<CarListRes> 반환으로 변경
```java
public List<CarListRes> searchCarListByCondition(Long centerId) {
        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));

        List<Long> carIds = queryFactory
                .select(car.id)
                .from(car)
                .where(
                        car.center.id.eq(centerId),
                        car.delYn.eq(DelYn.N)
                )
                .orderBy(car.createdAt.asc())
                .fetch();

        if (carIds.isEmpty()) {
            return Collections.emptyList();
        }

        BooleanTemplate runningExpr = Expressions.booleanTemplate(
                "sum(case when {0} = {1} then 1 else 0 end) > 0",
                path.driveStatus,
                DriveStatus.RUNNING
        );

        List<Tuple> carList = queryFactory
                .select(car, runningExpr)
                .from(car)
                .leftJoin(path).on(
                        path.car.id.eq(car.id)
                                .and(path.driveDate.eq(today))
                )
                .where(car.id.in(carIds))
                .groupBy(car.id)
                .orderBy(car.createdAt.asc())
                .fetch();

        return carList.stream()
                .map(tuple -> CarListRes.from(
                        tuple.get(car),
                        tuple.get(runningExpr)
                ))
                .toList();
    }
```

## ✅ 작업 항목
- [ ] 센터별 차량 조회 api 개발
- [ ] CarDocs에 추가

## 📎 참고 자료

### Tuple
#### 참고 문서 링크
- [다중 칼럼 결과 처리 Tuple 공식 문서](http://querydsl.com/static/querydsl/3.7.2/reference/ko-KR/html/ch03s02.html)

#### 장단점
구분 | 내용
-- | --
장점 | - 다양한 타입의 데이터를 한 번에 조회 가능 <br/>- 필요한 컬럼만 선택해 성능 최적화<br/>- DTO 없이 일회성/복잡한 쿼리 결과 처리에 유용
단점 | - 타입 안정성 낮아 런타임 오류 위험<br/>- 어떤 값인지 바로 알기 어려워 가독성 떨어짐<br/>- 결국 DTO로 매핑하는 코드 필요- API 응답용으로는 부적절

#### Tuple 적용이 적절하다고 생각한 이유
- 특정 컬럼 + 서브쿼리 조합을 사용하고 있기 때문에 복합 구조의 조회 결과를 일시적으로 저장할 때 유용하다고 판단
- CarListRes.from()을 사용해 carNumber의 포맷을 변경해야 해서 결국 DTO 맵핑을 해야 하기 때문에 타입 안정성이 떨어지지 않을 것으로 판단
