### PR TITLE
[Feat/#142] 센터 정보 조회 

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -45,20 +45,6 @@ dependencies {
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
-def querydslDir = layout.buildDirectory.dir("generated/querydsl").get().asFile
-
-tasks.withType(JavaCompile).configureEach {
-	options.generatedSourceOutputDirectory.set(querydslDir)
-}
-
-sourceSets {
-	main.java.srcDirs += [ querydslDir ]
-}
-
-clean.doLast {
-	file(querydslDir).deleteDir()
-}
-
 tasks.named('test') {
 	useJUnitPlatform()
 }

--- a/backend/src/main/java/hyfive/gachita/car/Car.java
+++ b/backend/src/main/java/hyfive/gachita/car/Car.java
@@ -61,5 +61,9 @@ public class Car {
         this.lowFloor = lowFloor;
         this.carImage = carImage;
     }
+
+    public void delete() {
+        this.delYn = DelYn.Y;
+    }
 }
 

--- a/backend/src/main/java/hyfive/gachita/car/CarController.java
+++ b/backend/src/main/java/hyfive/gachita/car/CarController.java
@@ -4,7 +4,6 @@ import hyfive.gachita.car.dto.CarListRes;
 import hyfive.gachita.car.dto.CarRes;
 import hyfive.gachita.car.dto.CreateCarReq;
 import hyfive.gachita.car.dto.UpdateCarReq;
-import hyfive.gachita.common.dto.ListRes;
 import hyfive.gachita.common.response.BaseResponse;
 import hyfive.gachita.docs.CarDocs;
 import jakarta.validation.constraints.NotNull;
@@ -12,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/car")
@@ -41,7 +42,7 @@ public class CarController implements CarDocs {
     }
 
     @GetMapping("/list")
-    public BaseResponse<ListRes<CarListRes>> getCarList(
+    public BaseResponse<List<CarListRes>> getCarList(
             @RequestParam(name = "center_id") Long centerId
     ) {
         return BaseResponse.success(carService.getCarList(centerId));

--- a/backend/src/main/java/hyfive/gachita/car/CarController.java
+++ b/backend/src/main/java/hyfive/gachita/car/CarController.java
@@ -48,7 +48,7 @@ public class CarController implements CarDocs {
         return BaseResponse.success(carService.getCarList(centerId));
     }
 
-    @PatchMapping("/{id}")
+    @DeleteMapping("/{id}")
     public BaseResponse<CarRes> deleteCar(@PathVariable("id") @NotNull Long id) {
         Car deleteCar = carService.deleteCar(id);
         return BaseResponse.success(CarRes.from(deleteCar));

--- a/backend/src/main/java/hyfive/gachita/car/CarController.java
+++ b/backend/src/main/java/hyfive/gachita/car/CarController.java
@@ -1,8 +1,10 @@
 package hyfive.gachita.car;
 
+import hyfive.gachita.car.dto.CarListRes;
 import hyfive.gachita.car.dto.CarRes;
 import hyfive.gachita.car.dto.CreateCarReq;
 import hyfive.gachita.car.dto.UpdateCarReq;
+import hyfive.gachita.common.dto.ListRes;
 import hyfive.gachita.common.response.BaseResponse;
 import hyfive.gachita.docs.CarDocs;
 import jakarta.validation.constraints.NotNull;
@@ -36,5 +38,12 @@ public class CarController implements CarDocs {
     public BaseResponse<CarRes> getCar(@PathVariable("id") @NotNull Long id) {
         Car getCar = carService.getCar(id);
         return BaseResponse.success(CarRes.from(getCar));
+    }
+
+    @GetMapping("/list")
+    public BaseResponse<ListRes<CarListRes>> getCarList(
+            @RequestParam(name = "center_id") Long centerId
+    ) {
+        return BaseResponse.success(carService.getCarList(centerId));
     }
 }

--- a/backend/src/main/java/hyfive/gachita/car/CarController.java
+++ b/backend/src/main/java/hyfive/gachita/car/CarController.java
@@ -47,4 +47,10 @@ public class CarController implements CarDocs {
     ) {
         return BaseResponse.success(carService.getCarList(centerId));
     }
+
+    @PatchMapping("/{id}")
+    public BaseResponse<CarRes> deleteCar(@PathVariable("id") @NotNull Long id) {
+        Car deleteCar = carService.deleteCar(id);
+        return BaseResponse.success(CarRes.from(deleteCar));
+    }
 }

--- a/backend/src/main/java/hyfive/gachita/car/CarService.java
+++ b/backend/src/main/java/hyfive/gachita/car/CarService.java
@@ -83,17 +83,10 @@ public class CarService {
         return car;
     }
 
-    public ListRes<CarListRes> getCarList(Long centerId) {
+    public List<CarListRes> getCarList(Long centerId) {
         centerRepository.findById(centerId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NO_EXIST_VALUE, "DB에 센터 데이터가 존재하지 않습니다."));
 
-        List<CarListRes> listResult = carRepository.searchCarListByCondition(centerId);
-
-        return ListRes.<CarListRes>builder()
-                .items(listResult)
-                .currentPageNum(1)
-                .totalPageNum(1)
-                .totalItemNum(listResult.size())
-                .build();
+        return carRepository.searchCarListByCondition(centerId);
     }
 }

--- a/backend/src/main/java/hyfive/gachita/car/CarService.java
+++ b/backend/src/main/java/hyfive/gachita/car/CarService.java
@@ -1,14 +1,19 @@
 package hyfive.gachita.car;
 
+import hyfive.gachita.car.dto.CarListRes;
 import hyfive.gachita.car.dto.CreateCarReq;
 import hyfive.gachita.car.dto.UpdateCarReq;
+import hyfive.gachita.car.repository.CarRepository;
 import hyfive.gachita.center.Center;
 import hyfive.gachita.center.CenterRepository;
+import hyfive.gachita.common.dto.ListRes;
 import hyfive.gachita.common.response.BusinessException;
 import hyfive.gachita.common.response.ErrorCode;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 import static hyfive.gachita.common.util.CarNumberFormatter.normalize;
 
@@ -76,5 +81,19 @@ public class CarService {
         Car car = carRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NO_EXIST_VALUE, "DB에 차량 데이터가 존재하지 않습니다."));
         return car;
+    }
+
+    public ListRes<CarListRes> getCarList(Long centerId) {
+        centerRepository.findById(centerId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NO_EXIST_VALUE, "DB에 센터 데이터가 존재하지 않습니다."));
+
+        List<CarListRes> listResult = carRepository.searchCarListByCondition(centerId);
+
+        return ListRes.<CarListRes>builder()
+                .items(listResult)
+                .currentPageNum(1)
+                .totalPageNum(1)
+                .totalItemNum(listResult.size())
+                .build();
     }
 }

--- a/backend/src/main/java/hyfive/gachita/car/CarService.java
+++ b/backend/src/main/java/hyfive/gachita/car/CarService.java
@@ -83,6 +83,7 @@ public class CarService {
         return car;
     }
 
+    @Transactional
     public List<CarListRes> getCarList(Long centerId) {
         centerRepository.findById(centerId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NO_EXIST_VALUE, "DB에 센터 데이터가 존재하지 않습니다."));

--- a/backend/src/main/java/hyfive/gachita/car/CarService.java
+++ b/backend/src/main/java/hyfive/gachita/car/CarService.java
@@ -6,7 +6,6 @@ import hyfive.gachita.car.dto.UpdateCarReq;
 import hyfive.gachita.car.repository.CarRepository;
 import hyfive.gachita.center.Center;
 import hyfive.gachita.center.CenterRepository;
-import hyfive.gachita.common.dto.ListRes;
 import hyfive.gachita.common.response.BusinessException;
 import hyfive.gachita.common.response.ErrorCode;
 import jakarta.transaction.Transactional;
@@ -89,5 +88,15 @@ public class CarService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.NO_EXIST_VALUE, "DB에 센터 데이터가 존재하지 않습니다."));
 
         return carRepository.searchCarListByCondition(centerId);
+    }
+
+    @Transactional
+    public Car deleteCar(Long id) {
+        Car car = carRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NO_EXIST_VALUE, "DB에 차량 데이터가 존재하지 않습니다."));
+
+        car.delete();
+
+        return car;
     }
 }

--- a/backend/src/main/java/hyfive/gachita/car/dto/CarListRes.java
+++ b/backend/src/main/java/hyfive/gachita/car/dto/CarListRes.java
@@ -26,9 +26,9 @@ public record CarListRes(
         String carImage,
 
         @Schema(description = "차량 운행 상태", example = "false")
-        Boolean running
+        Boolean driving
 ) {
-    public static CarListRes from(Car car, Boolean running) {
+    public static CarListRes from(Car car, Boolean driving) {
         return new CarListRes(
                 car.getId(),
                 car.getModelName(),
@@ -36,7 +36,7 @@ public record CarListRes(
                 car.getCapacity(),
                 car.getLowFloor(),
                 car.getCarImage(),
-                running
+                driving
         );
     }
 }

--- a/backend/src/main/java/hyfive/gachita/car/dto/CarListRes.java
+++ b/backend/src/main/java/hyfive/gachita/car/dto/CarListRes.java
@@ -1,0 +1,43 @@
+package hyfive.gachita.car.dto;
+
+import hyfive.gachita.car.Car;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import static hyfive.gachita.common.util.CarNumberFormatter.format;
+
+public record CarListRes(
+        @Schema(description = "차량 ID", example = "1")
+        Long id,
+
+        @Schema(description = "차량 모델명", example = "기아 레이")
+        String modelName,
+
+        @Schema(description = "차량 번호", example = "12가 3456")
+        String carNumber,
+
+        @Schema(description = "탑승 가능 인원 수", example = "3")
+        int capacity,
+
+        @Schema(description = "저상 차량 여부", example = "false")
+        Boolean lowFloor,
+
+        // TODO : carImage example 추가
+        @Schema(description = "차량 이미지 url", example = "(차후 추가 예정)")
+        String carImage,
+
+        @Schema(description = "차량 운행 상태", example = "false")
+        Boolean running
+) {
+    public static CarListRes from(Car car, Boolean running) {
+        return new CarListRes(
+                car.getId(),
+                car.getModelName(),
+                format(car.getCarNumber()),
+                car.getCapacity(),
+                car.getLowFloor(),
+                car.getCarImage(),
+                running
+        );
+    }
+}
+

--- a/backend/src/main/java/hyfive/gachita/car/dto/CarRes.java
+++ b/backend/src/main/java/hyfive/gachita/car/dto/CarRes.java
@@ -30,10 +30,7 @@ public record CarRes(
 
         // TODO : carImage example 추가
         @Schema(description = "차량 이미지 url", example = "(차후 추가 예정)")
-        String carImage,
-
-        @Schema(description = "차량 삭제 여부", example = "N")
-        DelYn delYn
+        String carImage
     ) {
     public static CarRes from(Car car) {
         return new CarRes(
@@ -44,8 +41,7 @@ public record CarRes(
                 format(car.getCarNumber()),
                 car.getCapacity(),
                 car.getLowFloor(),
-                car.getCarImage(),
-                car.getDelYn()
+                car.getCarImage()
         );
     }
 }

--- a/backend/src/main/java/hyfive/gachita/car/dto/CarRes.java
+++ b/backend/src/main/java/hyfive/gachita/car/dto/CarRes.java
@@ -1,6 +1,7 @@
 package hyfive.gachita.car.dto;
 
 import hyfive.gachita.car.Car;
+import hyfive.gachita.car.DelYn;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import static hyfive.gachita.common.util.CarNumberFormatter.format;
@@ -29,7 +30,10 @@ public record CarRes(
 
         // TODO : carImage example 추가
         @Schema(description = "차량 이미지 url", example = "(차후 추가 예정)")
-        String carImage
+        String carImage,
+
+        @Schema(description = "차량 삭제 여부", example = "N")
+        DelYn delYn
     ) {
     public static CarRes from(Car car) {
         return new CarRes(
@@ -40,7 +44,8 @@ public record CarRes(
                 format(car.getCarNumber()),
                 car.getCapacity(),
                 car.getLowFloor(),
-                car.getCarImage()
+                car.getCarImage(),
+                car.getDelYn()
         );
     }
 }

--- a/backend/src/main/java/hyfive/gachita/car/repository/CarRepository.java
+++ b/backend/src/main/java/hyfive/gachita/car/repository/CarRepository.java
@@ -1,9 +1,11 @@
-package hyfive.gachita.car;
+package hyfive.gachita.car.repository;
 
+import hyfive.gachita.car.Car;
+import hyfive.gachita.car.DelYn;
 import hyfive.gachita.center.Center;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CarRepository extends JpaRepository<Car, Long> {
+public interface CarRepository extends JpaRepository<Car, Long>, CustomCarRepository {
 
     long countByCenterAndDelYn(Center center, DelYn delYn);
 

--- a/backend/src/main/java/hyfive/gachita/car/repository/CustomCarRepository.java
+++ b/backend/src/main/java/hyfive/gachita/car/repository/CustomCarRepository.java
@@ -1,0 +1,9 @@
+package hyfive.gachita.car.repository;
+
+import hyfive.gachita.car.dto.CarListRes;
+
+import java.util.List;
+
+public interface CustomCarRepository {
+    List<CarListRes> searchCarListByCondition(Long centerId);
+}

--- a/backend/src/main/java/hyfive/gachita/car/repository/CustomCarRepositoryImpl.java
+++ b/backend/src/main/java/hyfive/gachita/car/repository/CustomCarRepositoryImpl.java
@@ -1,0 +1,68 @@
+package hyfive.gachita.car.repository;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.BooleanTemplate;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import hyfive.gachita.car.DelYn;
+import hyfive.gachita.car.dto.CarListRes;
+import hyfive.gachita.path.DriveStatus;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Collections;
+import java.util.List;
+
+import static hyfive.gachita.car.QCar.car;
+import static hyfive.gachita.path.QPath.path;
+
+@RequiredArgsConstructor
+public class CustomCarRepositoryImpl implements CustomCarRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<CarListRes> searchCarListByCondition(Long centerId) {
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+
+        List<Long> carIds = queryFactory
+                .select(car.id)
+                .from(car)
+                .where(
+                        car.center.id.eq(centerId),
+                        car.delYn.eq(DelYn.N)
+                )
+                .orderBy(car.createdAt.asc())
+                .fetch();
+
+        if (carIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        BooleanTemplate runningExpr = Expressions.booleanTemplate(
+                "sum(case when {0} = {1} then 1 else 0 end) > 0",
+                path.driveStatus,
+                DriveStatus.RUNNING
+        );
+
+        List<Tuple> carList = queryFactory
+                .select(car, runningExpr)
+                .from(car)
+                .leftJoin(path).on(
+                        path.car.id.eq(car.id)
+                                .and(path.driveDate.eq(today))
+                )
+                .where(car.id.in(carIds))
+                .groupBy(car.id)
+                .orderBy(car.createdAt.asc())
+                .fetch();
+
+        return carList.stream()
+                .map(tuple -> CarListRes.from(
+                        tuple.get(car),
+                        tuple.get(runningExpr)
+                ))
+                .toList();
+    }
+}

--- a/backend/src/main/java/hyfive/gachita/car/repository/CustomCarRepositoryImpl.java
+++ b/backend/src/main/java/hyfive/gachita/car/repository/CustomCarRepositoryImpl.java
@@ -40,14 +40,14 @@ public class CustomCarRepositoryImpl implements CustomCarRepository {
             return Collections.emptyList();
         }
 
-        BooleanTemplate runningExpr = Expressions.booleanTemplate(
+        BooleanTemplate drivingExpr = Expressions.booleanTemplate(
                 "sum(case when {0} = {1} then 1 else 0 end) > 0",
                 path.driveStatus,
                 DriveStatus.RUNNING
         );
 
         List<Tuple> carList = queryFactory
-                .select(car, runningExpr)
+                .select(car, drivingExpr)
                 .from(car)
                 .leftJoin(path).on(
                         path.car.id.eq(car.id)
@@ -61,7 +61,7 @@ public class CustomCarRepositoryImpl implements CustomCarRepository {
         return carList.stream()
                 .map(tuple -> CarListRes.from(
                         tuple.get(car),
-                        tuple.get(runningExpr)
+                        tuple.get(drivingExpr)
                 ))
                 .toList();
     }

--- a/backend/src/main/java/hyfive/gachita/car/repository/CustomCarRepositoryImpl.java
+++ b/backend/src/main/java/hyfive/gachita/car/repository/CustomCarRepositoryImpl.java
@@ -24,7 +24,7 @@ public class CustomCarRepositoryImpl implements CustomCarRepository {
 
     @Override
     public List<CarListRes> searchCarListByCondition(Long centerId) {
-        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        LocalDate today = LocalDate.now();
 
         List<Long> carIds = queryFactory
                 .select(car.id)

--- a/backend/src/main/java/hyfive/gachita/center/Center.java
+++ b/backend/src/main/java/hyfive/gachita/center/Center.java
@@ -5,7 +5,7 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
-import org.hibernate.annotations.CreationTimestamp;
+
 import java.time.LocalDateTime;
 import java.util.List;
 

--- a/backend/src/main/java/hyfive/gachita/center/Center.java
+++ b/backend/src/main/java/hyfive/gachita/center/Center.java
@@ -4,7 +4,6 @@ import hyfive.gachita.car.Car;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
-import lombok.Setter;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/backend/src/main/java/hyfive/gachita/center/Center.java
+++ b/backend/src/main/java/hyfive/gachita/center/Center.java
@@ -10,7 +10,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
-@Setter
 @Entity
 @Table(name = "center")
 public class Center {

--- a/backend/src/main/java/hyfive/gachita/center/CenterController.java
+++ b/backend/src/main/java/hyfive/gachita/center/CenterController.java
@@ -1,6 +1,10 @@
 package hyfive.gachita.center;
 
+import hyfive.gachita.common.response.BaseResponse;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -9,4 +13,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class CenterController {
     private final CenterService centerService;
+
+    @GetMapping("/{id}")
+    public BaseResponse<CenterRes> getCenter(@PathVariable("id") @NotNull Long id) {
+        Center center = centerService.getCenter(id);
+        return BaseResponse.success(CenterRes.from(center));
+    }
 }

--- a/backend/src/main/java/hyfive/gachita/center/CenterController.java
+++ b/backend/src/main/java/hyfive/gachita/center/CenterController.java
@@ -16,7 +16,7 @@ public class CenterController {
 
     @GetMapping("/{id}")
     public BaseResponse<CenterRes> getCenter(@PathVariable("id") @NotNull Long id) {
-        Center center = centerService.getCenter(id);
-        return BaseResponse.success(CenterRes.from(center));
+        CenterRes centerRes = centerService.getCenter(id);
+        return BaseResponse.success(centerRes);
     }
 }

--- a/backend/src/main/java/hyfive/gachita/center/CenterRes.java
+++ b/backend/src/main/java/hyfive/gachita/center/CenterRes.java
@@ -16,8 +16,8 @@ public record CenterRes(
         String centerAddr,
 
         @Schema(description = "등록 차량 대수", example = "4")
-        int carCount,
+        long carCount,
 
         @Schema(description = "이번 수 예상 수익", example = "1500000")
-        int payAmount
+        long payAmount
 ) {}

--- a/backend/src/main/java/hyfive/gachita/center/CenterRes.java
+++ b/backend/src/main/java/hyfive/gachita/center/CenterRes.java
@@ -1,0 +1,23 @@
+package hyfive.gachita.center;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "센터 응답 DTO")
+public record CenterRes(
+        @Schema(description = "센터 이름", example = "노원바른데이케어")
+        String centerName,
+
+        @Schema(description = "센터 전화번호", example = "02-1234-5678")
+        String centerTel,
+
+        @Schema(description = "센터 위치 주소", example = "서울특별시 노원구 동일로 123")
+        String centerAddr,
+
+        @Schema(description = "등록 차량 대수", example = "4")
+        int carCount,
+
+        @Schema(description = "이번 수 예상 수익", example = "1500000")
+        int weekAmount
+) {}

--- a/backend/src/main/java/hyfive/gachita/center/CenterRes.java
+++ b/backend/src/main/java/hyfive/gachita/center/CenterRes.java
@@ -19,5 +19,5 @@ public record CenterRes(
         int carCount,
 
         @Schema(description = "이번 수 예상 수익", example = "1500000")
-        int weekAmount
+        int payAmount
 ) {}

--- a/backend/src/main/java/hyfive/gachita/center/CenterService.java
+++ b/backend/src/main/java/hyfive/gachita/center/CenterService.java
@@ -11,8 +11,14 @@ import org.springframework.stereotype.Service;
 public class CenterService {
     private final CenterRepository centerRepository;
 
-    public Center getCenter(Long id) {
-        return centerRepository.findById(id)
+    public CenterRes getCenter(Long id) {
+        Center center = centerRepository.findById(id)
                 .orElseThrow(()-> new BusinessException(ErrorCode.NO_EXIST_VALUE, "DB에 센터 데이터가 존재하지 않습니다."));
+        return CenterRes.builder()
+                .centerName(center.getCenterName())
+                .centerAddr(center.getCenterAddr())
+                .centerTel(center.getCenterTel())
+                .carCount(center.getCarList().size())
+                .build();
     }
 }

--- a/backend/src/main/java/hyfive/gachita/center/CenterService.java
+++ b/backend/src/main/java/hyfive/gachita/center/CenterService.java
@@ -1,5 +1,8 @@
 package hyfive.gachita.center;
 
+import hyfive.gachita.car.Car;
+import hyfive.gachita.common.response.BusinessException;
+import hyfive.gachita.common.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -7,4 +10,9 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class CenterService {
     private final CenterRepository centerRepository;
+
+    public Center getCenter(Long id) {
+        return centerRepository.findById(id)
+                .orElseThrow(()-> new BusinessException(ErrorCode.NO_EXIST_VALUE, "DB에 센터 데이터가 존재하지 않습니다."));
+    }
 }

--- a/backend/src/main/java/hyfive/gachita/center/CenterService.java
+++ b/backend/src/main/java/hyfive/gachita/center/CenterService.java
@@ -1,8 +1,8 @@
 package hyfive.gachita.center;
 
-import hyfive.gachita.car.Car;
 import hyfive.gachita.common.response.BusinessException;
 import hyfive.gachita.common.response.ErrorCode;
+import hyfive.gachita.pay.PayService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -10,15 +10,20 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class CenterService {
     private final CenterRepository centerRepository;
+    private final PayService payService;
 
     public CenterRes getCenter(Long id) {
         Center center = centerRepository.findById(id)
                 .orElseThrow(()-> new BusinessException(ErrorCode.NO_EXIST_VALUE, "DB에 센터 데이터가 존재하지 않습니다."));
+
+        int weeklyPayAmount = payService.getWeeklyPayAmount(center.getId());
+
         return CenterRes.builder()
                 .centerName(center.getCenterName())
                 .centerAddr(center.getCenterAddr())
                 .centerTel(center.getCenterTel())
                 .carCount(center.getCarList().size())
+                .payAmount(weeklyPayAmount)
                 .build();
     }
 }

--- a/backend/src/main/java/hyfive/gachita/center/CenterService.java
+++ b/backend/src/main/java/hyfive/gachita/center/CenterService.java
@@ -1,5 +1,7 @@
 package hyfive.gachita.center;
 
+import hyfive.gachita.car.DelYn;
+import hyfive.gachita.car.repository.CarRepository;
 import hyfive.gachita.common.response.BusinessException;
 import hyfive.gachita.common.response.ErrorCode;
 import hyfive.gachita.pay.PayService;
@@ -10,19 +12,21 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class CenterService {
     private final CenterRepository centerRepository;
+    private final CarRepository carRepository;
     private final PayService payService;
 
     public CenterRes getCenter(Long id) {
         Center center = centerRepository.findById(id)
                 .orElseThrow(()-> new BusinessException(ErrorCode.NO_EXIST_VALUE, "DB에 센터 데이터가 존재하지 않습니다."));
 
-        int weeklyPayAmount = payService.getWeeklyPayAmount(center.getId());
+        long carCount = carRepository.countByCenterAndDelYn(center, DelYn.N);
+        long weeklyPayAmount = payService.getWeeklyPayAmount(center.getId());
 
         return CenterRes.builder()
                 .centerName(center.getCenterName())
                 .centerAddr(center.getCenterAddr())
                 .centerTel(center.getCenterTel())
-                .carCount(center.getCarList().size())
+                .carCount(carCount)
                 .payAmount(weeklyPayAmount)
                 .build();
     }

--- a/backend/src/main/java/hyfive/gachita/common/enums/SearchPeriod.java
+++ b/backend/src/main/java/hyfive/gachita/common/enums/SearchPeriod.java
@@ -18,8 +18,8 @@ public enum SearchPeriod {
             case TODAY -> Pair.of(today, today);
             case YESTERDAY -> Pair.of(today.minusDays(1), today.minusDays(1));
             case WEEK -> Pair.of(
-                    today.with(TemporalAdjusters.previous(DayOfWeek.SUNDAY)),
-                    today.with(DayOfWeek.SATURDAY)
+                    today.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY)),
+                    today.with(TemporalAdjusters.nextOrSame(DayOfWeek.SATURDAY))
             );
             case MONTH -> Pair.of(
                     today.withDayOfMonth(1),

--- a/backend/src/main/java/hyfive/gachita/docs/CarDocs.java
+++ b/backend/src/main/java/hyfive/gachita/docs/CarDocs.java
@@ -129,8 +129,7 @@ public interface CarDocs {
     @ApiResponses(value = {
             @ApiResponse(
                     responseCode = "1000",
-                    description = "차량 리스트 정보 조회 성공 시, 차량 리스트를 응답합니다.",
-                    content = @Content(schema = @Schema(implementation = CarRes.class))
+                    description = "차량 리스트 정보 조회 성공 시, 차량 리스트를 응답합니다."
             ),
             @ApiResponse(
                     responseCode = "2000",
@@ -145,5 +144,30 @@ public interface CarDocs {
     })
     BaseResponse<List<CarListRes>> getCarList(
             @RequestParam(name = "center_id") Long centerId
+    );
+
+    @Operation(
+            summary = "차량 삭제 API",
+            description = "차량 ID를 받아 차량을 삭제합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "1000",
+                    description = "차량 삭제 성공 시, 차량 정보를 응답합니다.",
+                    content = @Content(schema = @Schema(implementation = CarRes.class))
+            ),
+            @ApiResponse(
+                    responseCode = "2000",
+                    description = "필드가 비어있거나 잘못된 형식으로 요청한 경우 발생",
+                    content = @Content()
+            ),
+            @ApiResponse(
+                    responseCode = "3001",
+                    description = "요청한 차량 ID가 DB에 존재하지 않는 경우 발생",
+                    content = @Content()
+            )
+    })
+    BaseResponse<CarRes> deleteCar(
+            @PathVariable("id") @NotNull Long id
     );
 }

--- a/backend/src/main/java/hyfive/gachita/docs/CarDocs.java
+++ b/backend/src/main/java/hyfive/gachita/docs/CarDocs.java
@@ -4,7 +4,6 @@ import hyfive.gachita.car.dto.CarListRes;
 import hyfive.gachita.car.dto.CarRes;
 import hyfive.gachita.car.dto.CreateCarReq;
 import hyfive.gachita.car.dto.UpdateCarReq;
-import hyfive.gachita.common.dto.ListRes;
 import hyfive.gachita.common.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -16,6 +15,8 @@ import jakarta.validation.constraints.NotNull;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
 
 @Tag(name = "car", description = "차량 관련 API")
 public interface CarDocs {
@@ -142,7 +143,7 @@ public interface CarDocs {
                     content = @Content()
             )
     })
-    BaseResponse<ListRes<CarListRes>> getCarList(
+    BaseResponse<List<CarListRes>> getCarList(
             @RequestParam(name = "center_id") Long centerId
     );
 }

--- a/backend/src/main/java/hyfive/gachita/docs/CarDocs.java
+++ b/backend/src/main/java/hyfive/gachita/docs/CarDocs.java
@@ -1,8 +1,10 @@
 package hyfive.gachita.docs;
 
+import hyfive.gachita.car.dto.CarListRes;
 import hyfive.gachita.car.dto.CarRes;
 import hyfive.gachita.car.dto.CreateCarReq;
 import hyfive.gachita.car.dto.UpdateCarReq;
+import hyfive.gachita.common.dto.ListRes;
 import hyfive.gachita.common.response.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -13,6 +15,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "car", description = "차량 관련 API")
 public interface CarDocs {
@@ -116,5 +119,30 @@ public interface CarDocs {
     })
     BaseResponse<CarRes> getCar(
             @PathVariable("id") @NotNull Long id
+    );
+
+    @Operation(
+            summary = "센터별 차량 리스트 API",
+            description = "센터 ID를 받아 차량 리스트를 가져옵니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "1000",
+                    description = "차량 리스트 정보 조회 성공 시, 차량 리스트를 응답합니다.",
+                    content = @Content(schema = @Schema(implementation = CarRes.class))
+            ),
+            @ApiResponse(
+                    responseCode = "2000",
+                    description = "필드가 비어있거나 잘못된 형식으로 요청한 경우 발생",
+                    content = @Content()
+            ),
+            @ApiResponse(
+                    responseCode = "3001",
+                    description = "요청한 센터 ID가 DB에 존재하지 않는 경우 발생",
+                    content = @Content()
+            )
+    })
+    BaseResponse<ListRes<CarListRes>> getCarList(
+            @RequestParam(name = "center_id") Long centerId
     );
 }

--- a/backend/src/main/java/hyfive/gachita/pay/PayRepository.java
+++ b/backend/src/main/java/hyfive/gachita/pay/PayRepository.java
@@ -1,6 +1,0 @@
-package hyfive.gachita.pay;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface PayRepository extends JpaRepository<Pay, Long> {
-}

--- a/backend/src/main/java/hyfive/gachita/pay/PayService.java
+++ b/backend/src/main/java/hyfive/gachita/pay/PayService.java
@@ -1,10 +1,20 @@
 package hyfive.gachita.pay;
 
+import hyfive.gachita.common.enums.SearchPeriod;
+import hyfive.gachita.pay.repository.PayRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
 public class PayService {
     private final PayRepository payRepository;
+
+    public int getWeeklyPayAmount(Long centerId) {
+        Pair<LocalDateTime, LocalDateTime> currentWeekPeriod = SearchPeriod.getDateRange(SearchPeriod.WEEK);
+        return payRepository.getAmountByPeriod(centerId, currentWeekPeriod);
+    }
 }

--- a/backend/src/main/java/hyfive/gachita/pay/repository/CustomPayRepository.java
+++ b/backend/src/main/java/hyfive/gachita/pay/repository/CustomPayRepository.java
@@ -1,0 +1,9 @@
+package hyfive.gachita.pay.repository;
+
+import org.springframework.data.util.Pair;
+
+import java.time.LocalDateTime;
+
+public interface CustomPayRepository {
+    int getAmountByPeriod(Long centerId, Pair<LocalDateTime, LocalDateTime> period);
+}

--- a/backend/src/main/java/hyfive/gachita/pay/repository/CustomPayRepositoryImpl.java
+++ b/backend/src/main/java/hyfive/gachita/pay/repository/CustomPayRepositoryImpl.java
@@ -1,0 +1,34 @@
+package hyfive.gachita.pay.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.util.Pair;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static hyfive.gachita.pay.QPay.pay;
+
+@RequiredArgsConstructor
+public class CustomPayRepositoryImpl implements CustomPayRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+
+    @Override
+    public int getAmountByPeriod(Long centerId, Pair<LocalDateTime, LocalDateTime> period) {
+        LocalDate startDate = period.getFirst().toLocalDate();
+        LocalDate endDate = period.getSecond().toLocalDate();
+
+        Integer sum = queryFactory
+                .select(pay.amount.sum())
+                .from(pay)
+                .where(
+                        pay.center.id.eq(centerId),
+                        pay.payDate.between(startDate, endDate)
+                )
+                .fetchOne();
+
+        return sum != null ? sum : 0;
+    }
+}

--- a/backend/src/main/java/hyfive/gachita/pay/repository/PayRepository.java
+++ b/backend/src/main/java/hyfive/gachita/pay/repository/PayRepository.java
@@ -1,0 +1,11 @@
+package hyfive.gachita.pay.repository;
+
+import hyfive.gachita.pay.Pay;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.util.Pair;
+
+import java.time.LocalDateTime;
+
+public interface PayRepository extends JpaRepository<Pay, Long>, CustomPayRepository {
+    int getAmountByPeriod(Long centerId, Pair<LocalDateTime, LocalDateTime> period);
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Close #142 

## 📝 기능 설명
- `/api/center/{id}` 호출 시, 센터명, 전화번호, 주소, 등록 차량 대수, 이번주 정산 금액을 확인할 수 있습니다.
`/api/center/datail/{id}` 로 API 명세서에는 작성되어 있었는데, 다른 도메인의 API 요청 형식과 통일하는 것이 좋을 것 같아 우선 `/api/center/{id}`를 호출하면 해당 센터의 정보를 제공하도록 하였습니다.

- 차량 리스트
차량 리스트 조회 API 가 따로 분리된 것으로 이해하여 해당 API 에서는 해당 정보를 포함하지 않았습니다. 이 부분 확인하여 의견 부탁드립니다!

## 🛠 작업 사항
- 이번주 정산 금액 조회 - `PayService`, `PayRepository` 구현
센터 ID를 받아서 이번주 정산 금액을 받아오는 기능을 위해, 정산 서비스와 레포지토리를 구현하였습니다.

- 차량 대수 조회
차량 대수는 기존 CarRepository의 함수를 활용하였습니다.

- 일주일 범위를 SearchPeriod 오류 수정
조회 요일 기준 **일~월** 요일을 기준으로 일주일을 조회하는 SearchPeriod의 함수 범위가 잘못 지정되어 있어, 해당 부분을 수정하였습니다.

## 리뷰 요청 사항
정산 내역을 활용하기 위해서는 서비스, 차량 대수를 활용하기 위해서는 Repository를 주입받는데,
이 부분을 통일하면 좋을지 대해서 코멘트 부탁 드립니다..!

## ✅ 작업 항목
- [x] 센터 조회 기능 구현
- [ ] swagger 문서 작성

## 📎 참고 자료
<!-- 관련 문서, 링크, 스크린샷 등을 첨부해주세요 -->