### PR TITLE
[Feat/#142] 센터 정보 조회 `/api/center/{id}`

### DIFF
--- a/backend/src/main/java/hyfive/gachita/center/Center.java
+++ b/backend/src/main/java/hyfive/gachita/center/Center.java
@@ -4,7 +4,6 @@ import hyfive.gachita.car.Car;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
-import lombok.Setter;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/backend/src/main/java/hyfive/gachita/center/Center.java
+++ b/backend/src/main/java/hyfive/gachita/center/Center.java
@@ -10,7 +10,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
-@Setter
 @Entity
 @Table(name = "center")
 public class Center {

--- a/backend/src/main/java/hyfive/gachita/center/CenterController.java
+++ b/backend/src/main/java/hyfive/gachita/center/CenterController.java
@@ -1,6 +1,7 @@
 package hyfive.gachita.center;
 
 import hyfive.gachita.common.response.BaseResponse;
+import hyfive.gachita.docs.CenterDocs;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/center")
 @RequiredArgsConstructor
-public class CenterController {
+public class CenterController implements CenterDocs {
     private final CenterService centerService;
 
     @GetMapping("/{id}")

--- a/backend/src/main/java/hyfive/gachita/center/CenterController.java
+++ b/backend/src/main/java/hyfive/gachita/center/CenterController.java
@@ -1,6 +1,10 @@
 package hyfive.gachita.center;
 
+import hyfive.gachita.common.response.BaseResponse;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -9,4 +13,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class CenterController {
     private final CenterService centerService;
+
+    @GetMapping("/{id}")
+    public BaseResponse<CenterRes> getCenter(@PathVariable("id") @NotNull Long id) {
+        Center center = centerService.getCenter(id);
+        return BaseResponse.success(CenterRes.from(center));
+    }
 }

--- a/backend/src/main/java/hyfive/gachita/center/CenterController.java
+++ b/backend/src/main/java/hyfive/gachita/center/CenterController.java
@@ -16,7 +16,7 @@ public class CenterController {
 
     @GetMapping("/{id}")
     public BaseResponse<CenterRes> getCenter(@PathVariable("id") @NotNull Long id) {
-        Center center = centerService.getCenter(id);
-        return BaseResponse.success(CenterRes.from(center));
+        CenterRes centerRes = centerService.getCenter(id);
+        return BaseResponse.success(centerRes);
     }
 }

--- a/backend/src/main/java/hyfive/gachita/center/CenterRes.java
+++ b/backend/src/main/java/hyfive/gachita/center/CenterRes.java
@@ -16,8 +16,8 @@ public record CenterRes(
         String centerAddr,
 
         @Schema(description = "등록 차량 대수", example = "4")
-        int carCount,
+        long carCount,
 
         @Schema(description = "이번 수 예상 수익", example = "1500000")
-        int payAmount
+        long payAmount
 ) {}

--- a/backend/src/main/java/hyfive/gachita/center/CenterRes.java
+++ b/backend/src/main/java/hyfive/gachita/center/CenterRes.java
@@ -1,0 +1,23 @@
+package hyfive.gachita.center;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema(description = "센터 응답 DTO")
+public record CenterRes(
+        @Schema(description = "센터 이름", example = "노원바른데이케어")
+        String centerName,
+
+        @Schema(description = "센터 전화번호", example = "02-1234-5678")
+        String centerTel,
+
+        @Schema(description = "센터 위치 주소", example = "서울특별시 노원구 동일로 123")
+        String centerAddr,
+
+        @Schema(description = "등록 차량 대수", example = "4")
+        int carCount,
+
+        @Schema(description = "이번 수 예상 수익", example = "1500000")
+        int weekAmount
+) {}

--- a/backend/src/main/java/hyfive/gachita/center/CenterRes.java
+++ b/backend/src/main/java/hyfive/gachita/center/CenterRes.java
@@ -19,5 +19,5 @@ public record CenterRes(
         int carCount,
 
         @Schema(description = "이번 수 예상 수익", example = "1500000")
-        int weekAmount
+        int payAmount
 ) {}

--- a/backend/src/main/java/hyfive/gachita/center/CenterService.java
+++ b/backend/src/main/java/hyfive/gachita/center/CenterService.java
@@ -11,8 +11,14 @@ import org.springframework.stereotype.Service;
 public class CenterService {
     private final CenterRepository centerRepository;
 
-    public Center getCenter(Long id) {
-        return centerRepository.findById(id)
+    public CenterRes getCenter(Long id) {
+        Center center = centerRepository.findById(id)
                 .orElseThrow(()-> new BusinessException(ErrorCode.NO_EXIST_VALUE, "DB에 센터 데이터가 존재하지 않습니다."));
+        return CenterRes.builder()
+                .centerName(center.getCenterName())
+                .centerAddr(center.getCenterAddr())
+                .centerTel(center.getCenterTel())
+                .carCount(center.getCarList().size())
+                .build();
     }
 }

--- a/backend/src/main/java/hyfive/gachita/center/CenterService.java
+++ b/backend/src/main/java/hyfive/gachita/center/CenterService.java
@@ -1,5 +1,8 @@
 package hyfive.gachita.center;
 
+import hyfive.gachita.car.Car;
+import hyfive.gachita.common.response.BusinessException;
+import hyfive.gachita.common.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -7,4 +10,9 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class CenterService {
     private final CenterRepository centerRepository;
+
+    public Center getCenter(Long id) {
+        return centerRepository.findById(id)
+                .orElseThrow(()-> new BusinessException(ErrorCode.NO_EXIST_VALUE, "DB에 센터 데이터가 존재하지 않습니다."));
+    }
 }

--- a/backend/src/main/java/hyfive/gachita/center/CenterService.java
+++ b/backend/src/main/java/hyfive/gachita/center/CenterService.java
@@ -1,8 +1,8 @@
 package hyfive.gachita.center;
 
-import hyfive.gachita.car.Car;
 import hyfive.gachita.common.response.BusinessException;
 import hyfive.gachita.common.response.ErrorCode;
+import hyfive.gachita.pay.PayService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -10,15 +10,20 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class CenterService {
     private final CenterRepository centerRepository;
+    private final PayService payService;
 
     public CenterRes getCenter(Long id) {
         Center center = centerRepository.findById(id)
                 .orElseThrow(()-> new BusinessException(ErrorCode.NO_EXIST_VALUE, "DB에 센터 데이터가 존재하지 않습니다."));
+
+        int weeklyPayAmount = payService.getWeeklyPayAmount(center.getId());
+
         return CenterRes.builder()
                 .centerName(center.getCenterName())
                 .centerAddr(center.getCenterAddr())
                 .centerTel(center.getCenterTel())
                 .carCount(center.getCarList().size())
+                .payAmount(weeklyPayAmount)
                 .build();
     }
 }

--- a/backend/src/main/java/hyfive/gachita/center/CenterService.java
+++ b/backend/src/main/java/hyfive/gachita/center/CenterService.java
@@ -1,5 +1,7 @@
 package hyfive.gachita.center;
 
+import hyfive.gachita.car.DelYn;
+import hyfive.gachita.car.repository.CarRepository;
 import hyfive.gachita.common.response.BusinessException;
 import hyfive.gachita.common.response.ErrorCode;
 import hyfive.gachita.pay.PayService;
@@ -10,19 +12,21 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class CenterService {
     private final CenterRepository centerRepository;
+    private final CarRepository carRepository;
     private final PayService payService;
 
     public CenterRes getCenter(Long id) {
         Center center = centerRepository.findById(id)
                 .orElseThrow(()-> new BusinessException(ErrorCode.NO_EXIST_VALUE, "DB에 센터 데이터가 존재하지 않습니다."));
 
-        int weeklyPayAmount = payService.getWeeklyPayAmount(center.getId());
+        long carCount = carRepository.countByCenterAndDelYn(center, DelYn.N);
+        long weeklyPayAmount = payService.getWeeklyPayAmount(center.getId());
 
         return CenterRes.builder()
                 .centerName(center.getCenterName())
                 .centerAddr(center.getCenterAddr())
                 .centerTel(center.getCenterTel())
-                .carCount(center.getCarList().size())
+                .carCount(carCount)
                 .payAmount(weeklyPayAmount)
                 .build();
     }

--- a/backend/src/main/java/hyfive/gachita/common/enums/SearchPeriod.java
+++ b/backend/src/main/java/hyfive/gachita/common/enums/SearchPeriod.java
@@ -18,8 +18,8 @@ public enum SearchPeriod {
             case TODAY -> Pair.of(today, today);
             case YESTERDAY -> Pair.of(today.minusDays(1), today.minusDays(1));
             case WEEK -> Pair.of(
-                    today.with(TemporalAdjusters.previous(DayOfWeek.SUNDAY)),
-                    today.with(DayOfWeek.SATURDAY)
+                    today.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY)),
+                    today.with(TemporalAdjusters.nextOrSame(DayOfWeek.SATURDAY))
             );
             case MONTH -> Pair.of(
                     today.withDayOfMonth(1),

--- a/backend/src/main/java/hyfive/gachita/docs/CenterDocs.java
+++ b/backend/src/main/java/hyfive/gachita/docs/CenterDocs.java
@@ -1,0 +1,36 @@
+package hyfive.gachita.docs;
+
+import hyfive.gachita.center.CenterRes;
+import hyfive.gachita.common.response.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "center", description = "센터 관련 API")
+public interface CenterDocs {
+
+    @Operation(
+            summary = "센터 상세 정보 API",
+            description = "센터 ID를 받아 센터 상세 정보를 가져옵니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "1000",
+                    description = "센터 상세 정보 조회 성공 시, 센터 정보를 응답합니다.",
+                    content = @Content(schema = @Schema(implementation = CenterRes.class))
+            ),
+            @ApiResponse(
+                    responseCode = "3001",
+                    description = "요청한 센터 ID가 DB에 존재하지 않는 경우 발생",
+                    content = @Content()
+            )
+    })
+    BaseResponse<CenterRes> getCenter(
+            @PathVariable("id") @NotNull Long id
+    );
+}

--- a/backend/src/main/java/hyfive/gachita/pay/PayRepository.java
+++ b/backend/src/main/java/hyfive/gachita/pay/PayRepository.java
@@ -1,6 +1,0 @@
-package hyfive.gachita.pay;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface PayRepository extends JpaRepository<Pay, Long> {
-}

--- a/backend/src/main/java/hyfive/gachita/pay/PayService.java
+++ b/backend/src/main/java/hyfive/gachita/pay/PayService.java
@@ -1,10 +1,20 @@
 package hyfive.gachita.pay;
 
+import hyfive.gachita.common.enums.SearchPeriod;
+import hyfive.gachita.pay.repository.PayRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
 public class PayService {
     private final PayRepository payRepository;
+
+    public int getWeeklyPayAmount(Long centerId) {
+        Pair<LocalDateTime, LocalDateTime> currentWeekPeriod = SearchPeriod.getDateRange(SearchPeriod.WEEK);
+        return payRepository.getAmountByPeriod(centerId, currentWeekPeriod);
+    }
 }

--- a/backend/src/main/java/hyfive/gachita/pay/repository/CustomPayRepository.java
+++ b/backend/src/main/java/hyfive/gachita/pay/repository/CustomPayRepository.java
@@ -1,0 +1,9 @@
+package hyfive.gachita.pay.repository;
+
+import org.springframework.data.util.Pair;
+
+import java.time.LocalDateTime;
+
+public interface CustomPayRepository {
+    int getAmountByPeriod(Long centerId, Pair<LocalDateTime, LocalDateTime> period);
+}

--- a/backend/src/main/java/hyfive/gachita/pay/repository/CustomPayRepositoryImpl.java
+++ b/backend/src/main/java/hyfive/gachita/pay/repository/CustomPayRepositoryImpl.java
@@ -1,0 +1,34 @@
+package hyfive.gachita.pay.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.util.Pair;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static hyfive.gachita.pay.QPay.pay;
+
+@RequiredArgsConstructor
+public class CustomPayRepositoryImpl implements CustomPayRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+
+    @Override
+    public int getAmountByPeriod(Long centerId, Pair<LocalDateTime, LocalDateTime> period) {
+        LocalDate startDate = period.getFirst().toLocalDate();
+        LocalDate endDate = period.getSecond().toLocalDate();
+
+        Integer sum = queryFactory
+                .select(pay.amount.sum())
+                .from(pay)
+                .where(
+                        pay.center.id.eq(centerId),
+                        pay.payDate.between(startDate, endDate)
+                )
+                .fetchOne();
+
+        return sum != null ? sum : 0;
+    }
+}

--- a/backend/src/main/java/hyfive/gachita/pay/repository/PayRepository.java
+++ b/backend/src/main/java/hyfive/gachita/pay/repository/PayRepository.java
@@ -7,5 +7,4 @@ import org.springframework.data.util.Pair;
 import java.time.LocalDateTime;
 
 public interface PayRepository extends JpaRepository<Pay, Long>, CustomPayRepository {
-    int getAmountByPeriod(Long centerId, Pair<LocalDateTime, LocalDateTime> period);
 }

--- a/backend/src/main/java/hyfive/gachita/pay/repository/PayRepository.java
+++ b/backend/src/main/java/hyfive/gachita/pay/repository/PayRepository.java
@@ -1,0 +1,11 @@
+package hyfive.gachita.pay.repository;
+
+import hyfive.gachita.pay.Pay;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.util.Pair;
+
+import java.time.LocalDateTime;
+
+public interface PayRepository extends JpaRepository<Pay, Long>, CustomPayRepository {
+    int getAmountByPeriod(Long centerId, Pair<LocalDateTime, LocalDateTime> period);
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Close #142 

## 📝 기능 설명
- `/api/center/{id}` 호출 시, 센터명, 전화번호, 주소, 등록 차량 대수, 이번주 정산 금액을 확인할 수 있습니다.
`/api/center/datail/{id}` 로 API 명세서에는 작성되어 있었는데, 다른 도메인의 API 요청 형식과 통일하는 것이 좋을 것 같아 우선 `/api/center/{id}`를 호출하면 해당 센터의 정보를 제공하도록 하였습니다.

- 차량 리스트
차량 리스트 조회 API 가 따로 분리된 것으로 이해하여 해당 API 에서는 해당 정보를 포함하지 않았습니다. 이 부분 확인하여 의견 부탁드립니다!

## 🛠 작업 사항
- 이번주 정산 금액 조회 - `PayService`, `PayRepository` 구현
센터 ID를 받아서 이번주 정산 금액을 받아오는 기능을 위해, 정산 서비스와 레포지토리를 구현하였습니다.

- 차량 대수 조회
차량 대수는 기존 CarRepository의 함수를 활용하였습니다.

- 일주일 범위를 SearchPeriod 오류 수정
조회 요일 기준 **일~월** 요일을 기준으로 일주일을 조회하는 SearchPeriod의 함수 범위가 잘못 지정되어 있어, 해당 부분을 수정하였습니다.

## 리뷰 요청 사항
정산 내역을 활용하기 위해서는 서비스, 차량 대수를 활용하기 위해서는 Repository를 주입받는데,
이 부분을 통일하면 좋을지 대해서 코멘트 부탁 드립니다..!

## ✅ 작업 항목
- [x] 센터 조회 기능 구현
- [x] swagger 문서 작성

## 📎 참고 자료
<!-- 관련 문서, 링크, 스크린샷 등을 첨부해주세요 -->