### PR TITLE
[ Feat/#121 ] 차량 유휴 시간 교체: `POST /api/rental?car_id=?date=`

### DIFF
--- a/backend/src/main/java/hyfive/gachita/common/response/ErrorCode.java
+++ b/backend/src/main/java/hyfive/gachita/common/response/ErrorCode.java
@@ -29,7 +29,10 @@ public enum ErrorCode {
     DUPLICATE_CAR_NUMBER(false, 4501, "동일한 차량 번호를 가진 차량이 존재합니다."),
 
     /*예약 5000*/
-    DUPLICATE_BOOK_DATE(false, 5000, "동일한 사용자에 의해 이미 예약된 날짜입니다.");
+    DUPLICATE_BOOK_DATE(false, 5000, "동일한 사용자에 의해 이미 예약된 날짜입니다."),
+
+    /*유휴 시간 6000*/
+    INVALID_DURATION(false, 6000, "유휴시간은 최소 2시간 이상이어야 합니다.");
 
     private final boolean isSuccess;
     private final int code;

--- a/backend/src/main/java/hyfive/gachita/docs/RentalDocs.java
+++ b/backend/src/main/java/hyfive/gachita/docs/RentalDocs.java
@@ -1,0 +1,71 @@
+package hyfive.gachita.docs;
+
+import hyfive.gachita.common.response.BaseResponse;
+import hyfive.gachita.rental.dto.ReplaceRental;
+import hyfive.gachita.rental.dto.RentalRes;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.validation.annotation.Validated;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface RentalDocs {
+
+    @Operation(
+            summary = "유휴 시간 생성 API",
+            description = "차량 id, 날짜, 유휴 시간 리스트 정보를 받아 새로운 유휴 시간을 생성합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "1000",
+                    description = "예약 생성 성공 시, 유휴 시간 id, 차량 id 데이터를 추가하여 유휴시간 리스트 응답",
+                    content = @Content(schema = @Schema(implementation = RentalRes.class))
+            ),
+            @ApiResponse(
+                    responseCode = "2000",
+                    description = "필드가 비어있거나 잘못된 body 형식이 요청이 발생하는 경우",
+                    content = @Content()
+            ),
+            @ApiResponse(
+                    responseCode = "3001",
+                    description = "등록하려는 유휴시간의 차량이 DB에 존재하지 않는 경우 발생",
+                    content = @Content()
+            ),
+            @ApiResponse(
+                    responseCode = "6000",
+                    description = "2시간 미만 유휴 시간이 존재하는 경우",
+                    content = @Content()
+            )
+    })
+    BaseResponse<List<RentalRes>> replaceWeeklyRentals(
+            @Parameter(
+                    name = "car_id",
+                    description = "유휴 시간을 등록하려는 차량 id",
+                    required = true,
+                    example = "1"
+            )
+            @NotNull(message = "차량 id는 필수입니다.") Long carId,
+
+            @Parameter(
+                    name = "date",
+                    description = "유휴 시간을 등록하려는 주의 특정 날짜",
+                    required = true,
+                    example = "2025-08-20"
+            )
+            @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate targetDate,
+
+            @RequestBody(
+                    description = "유휴 시간 등록 DTO",
+                    required = true
+            )
+            @Validated List<ReplaceRental> rentalList
+    );
+}

--- a/backend/src/main/java/hyfive/gachita/rental/Rental.java
+++ b/backend/src/main/java/hyfive/gachita/rental/Rental.java
@@ -3,14 +3,15 @@ package hyfive.gachita.rental;
 import hyfive.gachita.car.Car;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
 
 @Getter
-@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Entity
 @Table(name = "rental")
 public class Rental {

--- a/backend/src/main/java/hyfive/gachita/rental/RentalController.java
+++ b/backend/src/main/java/hyfive/gachita/rental/RentalController.java
@@ -1,6 +1,7 @@
 package hyfive.gachita.rental;
 
 import hyfive.gachita.common.response.BaseResponse;
+import hyfive.gachita.docs.RentalDocs;
 import hyfive.gachita.rental.dto.ReplaceRental;
 import hyfive.gachita.rental.dto.RentalRes;
 import jakarta.validation.constraints.NotNull;
@@ -14,7 +15,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/rental")
 @RequiredArgsConstructor
-public class RentalController {
+public class RentalController implements RentalDocs {
     private final RentalService rentalService;
 
     @PostMapping

--- a/backend/src/main/java/hyfive/gachita/rental/RentalController.java
+++ b/backend/src/main/java/hyfive/gachita/rental/RentalController.java
@@ -1,12 +1,30 @@
 package hyfive.gachita.rental;
 
+import hyfive.gachita.common.response.BaseResponse;
+import hyfive.gachita.rental.dto.ReplaceRental;
+import hyfive.gachita.rental.dto.RentalRes;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/rental")
 @RequiredArgsConstructor
 public class RentalController {
     private final RentalService rentalService;
+
+    @PostMapping
+    public BaseResponse<List<RentalRes>> replaceWeeklyRentals(
+            @RequestParam("car_id") @NotNull(message = "차량 id는 필수입니다.") Long carId,
+            @RequestParam("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate targetDate,
+            @RequestBody List<ReplaceRental> rentalList
+    ) {
+        List<RentalRes> replaceResult = rentalService.replaceWeeklyRentals(carId, targetDate, rentalList);
+        return BaseResponse.success(replaceResult);
+    }
+
 }

--- a/backend/src/main/java/hyfive/gachita/rental/RentalRepository.java
+++ b/backend/src/main/java/hyfive/gachita/rental/RentalRepository.java
@@ -1,6 +1,0 @@
-package hyfive.gachita.rental;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface RentalRepository extends JpaRepository<Rental, Long> {
-}

--- a/backend/src/main/java/hyfive/gachita/rental/RentalService.java
+++ b/backend/src/main/java/hyfive/gachita/rental/RentalService.java
@@ -1,5 +1,6 @@
 package hyfive.gachita.rental;
 
+import hyfive.gachita.rental.repository.RentalRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/backend/src/main/java/hyfive/gachita/rental/RentalService.java
+++ b/backend/src/main/java/hyfive/gachita/rental/RentalService.java
@@ -1,11 +1,61 @@
 package hyfive.gachita.rental;
 
+import hyfive.gachita.car.Car;
+import hyfive.gachita.car.repository.CarRepository;
+import hyfive.gachita.common.response.BusinessException;
+import hyfive.gachita.common.response.ErrorCode;
+import hyfive.gachita.rental.dto.ReplaceRental;
+import hyfive.gachita.rental.dto.RentalRes;
 import hyfive.gachita.rental.repository.RentalRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.time.DayOfWeek;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class RentalService {
+
     private final RentalRepository rentalRepository;
+    private final CarRepository carRepository;
+
+    @Transactional
+    public List<RentalRes> replaceWeeklyRentals(Long carId, LocalDate targetDate, List<ReplaceRental> rentalList) {
+        Car car = carRepository.findById(carId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NO_EXIST_VALUE, "DB에 차량 데이터가 존재하지 않습니다."));
+
+        if (invalidDuration(rentalList)) {
+            throw new BusinessException(ErrorCode.INVALID_DURATION, "유휴시간은 최소 2시간 이상이어야 합니다.");
+        }
+
+        // TODO : SearchPeriod 병합되면 유진님과 enum 확장 논의
+        LocalDate startOfWeek = targetDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
+        LocalDate endOfWeek = startOfWeek.plusDays(6);
+
+        rentalRepository.deleteRentalsBetween(carId, startOfWeek, endOfWeek);
+
+        List<Rental> rentalsToSave = rentalList.stream()
+                .map(dto -> Rental.builder()
+                        .car(car)
+                        .rentalDate(dto.rentalDate())
+                        .rentalStartTime(dto.rentalStartTime())
+                        .rentalEndTime(dto.rentalEndTime())
+                        .build()
+                ).toList();
+
+        return rentalRepository.saveAll(rentalsToSave)
+                .stream()
+                .map(RentalRes::from).toList();
+    }
+
+    private boolean invalidDuration(List<ReplaceRental> rentalList) {
+        return rentalList.stream()
+                .anyMatch(dto -> Duration.between(dto.rentalStartTime(), dto.rentalEndTime()).toHours() < 2);
+    }
+
 }

--- a/backend/src/main/java/hyfive/gachita/rental/dto/RentalRes.java
+++ b/backend/src/main/java/hyfive/gachita/rental/dto/RentalRes.java
@@ -1,0 +1,39 @@
+package hyfive.gachita.rental.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import hyfive.gachita.rental.Rental;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Schema(description = "유휴 시간 응답 DTO")
+public record RentalRes(
+        @Schema(description = "유휴 시간 ID", example = "1")
+        Long id,
+
+        @Schema(description = "차량 ID", example = "1")
+        Long carId,
+
+        @Schema(description = "유휴 날짜 (yyyy-MM-dd)", example = "2025-08-20")
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate rentalDate,
+
+        @Schema(description = "유휴 시작 시간 (HH:mm)", example = "10:00")
+        @JsonFormat(pattern = "HH:mm")
+        LocalTime rentalStartTime,
+
+        @Schema(description = "유휴 종료 시간 (HH:mm)", example = "14:00")
+        @JsonFormat(pattern = "HH:mm")
+        LocalTime rentalEndTime
+) {
+    public static RentalRes from(Rental rental) {
+        return new RentalRes(
+                rental.getId(),
+                rental.getCar().getId(),
+                rental.getRentalDate(),
+                rental.getRentalStartTime(),
+                rental.getRentalEndTime()
+        );
+    }
+}

--- a/backend/src/main/java/hyfive/gachita/rental/dto/ReplaceRental.java
+++ b/backend/src/main/java/hyfive/gachita/rental/dto/ReplaceRental.java
@@ -1,0 +1,22 @@
+package hyfive.gachita.rental.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Schema(description = "유휴 시간 생성 요청 DTO")
+public record ReplaceRental(
+        @Schema(description = "유휴 날짜 (yyyy-MM-dd)", example = "2025-08-20")
+        @NotNull(message = "유휴 날짜는 필수입니다.")
+        LocalDate rentalDate,
+
+        @Schema(description = "유휴 시작 시간 (HH:mm)", example = "10:00")
+        @NotNull(message = "유휴 시작 시간은 필수입니다.")
+        LocalTime rentalStartTime,
+
+        @Schema(description = "유휴 종료 시간 (HH:mm)", example = "14:00")
+        @NotNull(message = "유휴 종료 시간은 필수입니다.")
+        LocalTime rentalEndTime
+) {}

--- a/backend/src/main/java/hyfive/gachita/rental/repository/CustomRentalRepository.java
+++ b/backend/src/main/java/hyfive/gachita/rental/repository/CustomRentalRepository.java
@@ -1,0 +1,8 @@
+package hyfive.gachita.rental.repository;
+
+import java.time.LocalDate;
+
+public interface CustomRentalRepository {
+
+    void deleteRentalsBetween(Long carId, LocalDate startDate, LocalDate endDate);
+}

--- a/backend/src/main/java/hyfive/gachita/rental/repository/CustomRentalRepositoryImpl.java
+++ b/backend/src/main/java/hyfive/gachita/rental/repository/CustomRentalRepositoryImpl.java
@@ -1,0 +1,27 @@
+package hyfive.gachita.rental.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+
+import static hyfive.gachita.rental.QRental.rental;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomRentalRepositoryImpl implements CustomRentalRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public void deleteRentalsBetween(Long carId, LocalDate startDate, LocalDate endDate) {
+        queryFactory
+                .delete(rental)
+                .where(
+                        rental.car.id.eq(carId)
+                                .and(rental.rentalDate.between(startDate, endDate))
+                )
+                .execute();
+    }
+}

--- a/backend/src/main/java/hyfive/gachita/rental/repository/RentalRepository.java
+++ b/backend/src/main/java/hyfive/gachita/rental/repository/RentalRepository.java
@@ -1,0 +1,7 @@
+package hyfive.gachita.rental.repository;
+
+import hyfive.gachita.rental.Rental;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RentalRepository extends JpaRepository<Rental, Long>, CustomRentalRepository {
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Close #121 

## 📝 기능 설명

- 전달받은 car_id, date를 기반으로 유휴 시간 리스트를 저장합니다.
- car_id와 date 기준, 기존에 저장되었던 유휴 시간은 삭제 됩니다.
- 교체 의미 : (등록, 수정, 삭제 전부 포함)

## 🛠 작업 사항

### 로직 진행 과정

1. car 존재 여부, 2시간 미만 유휴 시간 validation 
2. targetDate 기준 한 주 기간 조회
3. 기간과 carId에 해당하는 모든 유휴시간 삭제
4. 새로 들어온 유휴시간 등록 

### 리뷰 요청 사항

- 유휴 시간에서 한 주 범위를 구하는 것은, 오늘 날짜 기준이 아니라 입력받은 날짜 기준이어야 해서 유진님이 만들어주신 SearchPeriod enum이랑 조금 다른 부분이 있는 것 같아요. 지금처럼 RentalService 단에서 처리하면 좋을지, SearchPeriod를 확장하면 좋을지 의견 부탁드립니다! 
  - 의견 : 개인적인 의견으론, RentalService 단에서 처리하는 것이 좋을 것 같습니다.
  - 사유: SearchPeriod를 확장하면, enum을 호출할 때 마다 기준 날짜를 인자로 주어야 해서, 날짜 필터링을 하는 리스트 api에서 사용하기 번거로울 것 같다고 생각합니다

## ✅ 작업 항목
- [x] api 개발
- [x] Docs 작성
- [x] 재민님께 최종 컨펌

## 📎 참고 자료
