### PR TITLE
[Feat/#122] 차량 유휴 시간 리스트 조회: `GET /api/rental/list?car_id=&date=`

### DIFF
--- a/backend/src/main/java/hyfive/gachita/common/response/ErrorCode.java
+++ b/backend/src/main/java/hyfive/gachita/common/response/ErrorCode.java
@@ -29,7 +29,10 @@ public enum ErrorCode {
     DUPLICATE_CAR_NUMBER(false, 4501, "동일한 차량 번호를 가진 차량이 존재합니다."),
 
     /*예약 5000*/
-    DUPLICATE_BOOK_DATE(false, 5000, "동일한 사용자에 의해 이미 예약된 날짜입니다.");
+    DUPLICATE_BOOK_DATE(false, 5000, "동일한 사용자에 의해 이미 예약된 날짜입니다."),
+
+    /*유휴 시간 6000*/
+    INVALID_DURATION(false, 6000, "유휴시간은 최소 2시간 이상이어야 합니다.");
 
     private final boolean isSuccess;
     private final int code;

--- a/backend/src/main/java/hyfive/gachita/docs/RentalDocs.java
+++ b/backend/src/main/java/hyfive/gachita/docs/RentalDocs.java
@@ -58,7 +58,7 @@ public interface RentalDocs {
                     name = "date",
                     description = "유휴 시간을 등록하려는 주의 특정 날짜",
                     required = true,
-                    example = "2025-08-20"
+                    example = "2025-08-17"
             )
             @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate targetDate,
 
@@ -67,5 +67,44 @@ public interface RentalDocs {
                     required = true
             )
             @Validated List<ReplaceRental> rentalList
+    );
+
+    @Operation(
+            summary = "유휴 시간 리스트 조회 API",
+            description = "차량 id, 날짜, 유휴 시간 리스트 정보를 받아 유휴 시간 리스트를 조회합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "1000",
+                    description = "유휴 시간 조회 성공 시, 유휴 시간 id, 차량 id 데이터를 추가하여 유휴시간 리스트 응답",
+                    content = @Content(schema = @Schema(implementation = RentalRes.class))
+            ),
+            @ApiResponse(
+                    responseCode = "2000",
+                    description = "필드가 비어있거나 잘못된 body 형식이 요청이 발생하는 경우",
+                    content = @Content()
+            ),
+            @ApiResponse(
+                    responseCode = "3001",
+                    description = "조회하려는 유휴시간의 차량이 DB에 존재하지 않는 경우 발생",
+                    content = @Content()
+            )
+    })
+    BaseResponse<List<RentalRes>> getRentalList(
+            @Parameter(
+                    name = "car_id",
+                    description = "유휴 시간을 조회하려는 차량 id",
+                    required = true,
+                    example = "1"
+            )
+            @NotNull(message = "차량 id는 필수입니다.") Long carId,
+
+            @Parameter(
+                    name = "date",
+                    description = "유휴 시간을 조회하려는 주의 특정 날짜",
+                    required = true,
+                    example = "2025-08-17"
+            )
+            @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate targetDate
     );
 }

--- a/backend/src/main/java/hyfive/gachita/docs/RentalDocs.java
+++ b/backend/src/main/java/hyfive/gachita/docs/RentalDocs.java
@@ -1,0 +1,71 @@
+package hyfive.gachita.docs;
+
+import hyfive.gachita.common.response.BaseResponse;
+import hyfive.gachita.rental.dto.ReplaceRental;
+import hyfive.gachita.rental.dto.RentalRes;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.validation.annotation.Validated;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface RentalDocs {
+
+    @Operation(
+            summary = "유휴 시간 생성 API",
+            description = "차량 id, 날짜, 유휴 시간 리스트 정보를 받아 새로운 유휴 시간을 생성합니다."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "1000",
+                    description = "예약 생성 성공 시, 유휴 시간 id, 차량 id 데이터를 추가하여 유휴시간 리스트 응답",
+                    content = @Content(schema = @Schema(implementation = RentalRes.class))
+            ),
+            @ApiResponse(
+                    responseCode = "2000",
+                    description = "필드가 비어있거나 잘못된 body 형식이 요청이 발생하는 경우",
+                    content = @Content()
+            ),
+            @ApiResponse(
+                    responseCode = "3001",
+                    description = "등록하려는 유휴시간의 차량이 DB에 존재하지 않는 경우 발생",
+                    content = @Content()
+            ),
+            @ApiResponse(
+                    responseCode = "6000",
+                    description = "2시간 미만 유휴 시간이 존재하는 경우",
+                    content = @Content()
+            )
+    })
+    BaseResponse<List<RentalRes>> replaceWeeklyRentals(
+            @Parameter(
+                    name = "car_id",
+                    description = "유휴 시간을 등록하려는 차량 id",
+                    required = true,
+                    example = "1"
+            )
+            @NotNull(message = "차량 id는 필수입니다.") Long carId,
+
+            @Parameter(
+                    name = "date",
+                    description = "유휴 시간을 등록하려는 주의 특정 날짜",
+                    required = true,
+                    example = "2025-08-20"
+            )
+            @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate targetDate,
+
+            @RequestBody(
+                    description = "유휴 시간 등록 DTO",
+                    required = true
+            )
+            @Validated List<ReplaceRental> rentalList
+    );
+}

--- a/backend/src/main/java/hyfive/gachita/rental/Rental.java
+++ b/backend/src/main/java/hyfive/gachita/rental/Rental.java
@@ -3,14 +3,15 @@ package hyfive.gachita.rental;
 import hyfive.gachita.car.Car;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
 
 @Getter
-@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 @Entity
 @Table(name = "rental")
 public class Rental {

--- a/backend/src/main/java/hyfive/gachita/rental/RentalController.java
+++ b/backend/src/main/java/hyfive/gachita/rental/RentalController.java
@@ -28,4 +28,12 @@ public class RentalController implements RentalDocs {
         return BaseResponse.success(replaceResult);
     }
 
+    @GetMapping
+    public List<RentalRes> getRentalList(
+            @RequestParam("car_id") @NotNull(message = "차량 id는 필수입니다.") Long carId,
+            @RequestParam("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate targetDate
+    ) {
+        return rentalService.getRentalList(carId, targetDate);
+    }
+
 }

--- a/backend/src/main/java/hyfive/gachita/rental/RentalController.java
+++ b/backend/src/main/java/hyfive/gachita/rental/RentalController.java
@@ -1,6 +1,7 @@
 package hyfive.gachita.rental;
 
 import hyfive.gachita.common.response.BaseResponse;
+import hyfive.gachita.docs.RentalDocs;
 import hyfive.gachita.rental.dto.ReplaceRental;
 import hyfive.gachita.rental.dto.RentalRes;
 import jakarta.validation.constraints.NotNull;
@@ -14,7 +15,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/api/rental")
 @RequiredArgsConstructor
-public class RentalController {
+public class RentalController implements RentalDocs {
     private final RentalService rentalService;
 
     @PostMapping

--- a/backend/src/main/java/hyfive/gachita/rental/RentalController.java
+++ b/backend/src/main/java/hyfive/gachita/rental/RentalController.java
@@ -1,12 +1,30 @@
 package hyfive.gachita.rental;
 
+import hyfive.gachita.common.response.BaseResponse;
+import hyfive.gachita.rental.dto.ReplaceRental;
+import hyfive.gachita.rental.dto.RentalRes;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/rental")
 @RequiredArgsConstructor
 public class RentalController {
     private final RentalService rentalService;
+
+    @PostMapping
+    public BaseResponse<List<RentalRes>> replaceWeeklyRentals(
+            @RequestParam("car_id") @NotNull(message = "차량 id는 필수입니다.") Long carId,
+            @RequestParam("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate targetDate,
+            @RequestBody List<ReplaceRental> rentalList
+    ) {
+        List<RentalRes> replaceResult = rentalService.replaceWeeklyRentals(carId, targetDate, rentalList);
+        return BaseResponse.success(replaceResult);
+    }
+
 }

--- a/backend/src/main/java/hyfive/gachita/rental/RentalController.java
+++ b/backend/src/main/java/hyfive/gachita/rental/RentalController.java
@@ -29,11 +29,11 @@ public class RentalController implements RentalDocs {
     }
 
     @GetMapping
-    public List<RentalRes> getRentalList(
+    public BaseResponse<List<RentalRes>> getRentalList(
             @RequestParam("car_id") @NotNull(message = "차량 id는 필수입니다.") Long carId,
             @RequestParam("date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate targetDate
     ) {
-        return rentalService.getRentalList(carId, targetDate);
+        return BaseResponse.success(rentalService.getRentalList(carId, targetDate));
     }
 
 }

--- a/backend/src/main/java/hyfive/gachita/rental/RentalRepository.java
+++ b/backend/src/main/java/hyfive/gachita/rental/RentalRepository.java
@@ -1,6 +1,0 @@
-package hyfive.gachita.rental;
-
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface RentalRepository extends JpaRepository<Rental, Long> {
-}

--- a/backend/src/main/java/hyfive/gachita/rental/RentalService.java
+++ b/backend/src/main/java/hyfive/gachita/rental/RentalService.java
@@ -53,6 +53,19 @@ public class RentalService {
                 .map(RentalRes::from).toList();
     }
 
+    public List<RentalRes> getWeeklyRentals(Long carId, LocalDate targetDate) {
+        Car car = carRepository.findById(carId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NO_EXIST_VALUE, "DB에 차량 데이터가 존재하지 않습니다."));
+
+        // TODO : SearchPeriod 병합되면 유진님과 enum 확장 논의
+        LocalDate startOfWeek = targetDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
+        LocalDate endOfWeek = startOfWeek.plusDays(6);
+
+        return rentalRepository.findRentalsBetween(carId, startOfWeek, endOfWeek).stream()
+                .map(RentalRes::from)
+                .toList();
+    }
+
     private boolean invalidDuration(List<ReplaceRental> rentalList) {
         return rentalList.stream()
                 .anyMatch(dto -> Duration.between(dto.rentalStartTime(), dto.rentalEndTime()).toHours() < 2);

--- a/backend/src/main/java/hyfive/gachita/rental/RentalService.java
+++ b/backend/src/main/java/hyfive/gachita/rental/RentalService.java
@@ -1,5 +1,6 @@
 package hyfive.gachita.rental;
 
+import hyfive.gachita.rental.repository.RentalRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/backend/src/main/java/hyfive/gachita/rental/RentalService.java
+++ b/backend/src/main/java/hyfive/gachita/rental/RentalService.java
@@ -1,11 +1,61 @@
 package hyfive.gachita.rental;
 
+import hyfive.gachita.car.Car;
+import hyfive.gachita.car.repository.CarRepository;
+import hyfive.gachita.common.response.BusinessException;
+import hyfive.gachita.common.response.ErrorCode;
+import hyfive.gachita.rental.dto.ReplaceRental;
+import hyfive.gachita.rental.dto.RentalRes;
 import hyfive.gachita.rental.repository.RentalRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.time.DayOfWeek;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class RentalService {
+
     private final RentalRepository rentalRepository;
+    private final CarRepository carRepository;
+
+    @Transactional
+    public List<RentalRes> replaceWeeklyRentals(Long carId, LocalDate targetDate, List<ReplaceRental> rentalList) {
+        Car car = carRepository.findById(carId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NO_EXIST_VALUE, "DB에 차량 데이터가 존재하지 않습니다."));
+
+        if (invalidDuration(rentalList)) {
+            throw new BusinessException(ErrorCode.INVALID_DURATION, "유휴시간은 최소 2시간 이상이어야 합니다.");
+        }
+
+        // TODO : SearchPeriod 병합되면 유진님과 enum 확장 논의
+        LocalDate startOfWeek = targetDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
+        LocalDate endOfWeek = startOfWeek.plusDays(6);
+
+        rentalRepository.deleteRentalsBetween(carId, startOfWeek, endOfWeek);
+
+        List<Rental> rentalsToSave = rentalList.stream()
+                .map(dto -> Rental.builder()
+                        .car(car)
+                        .rentalDate(dto.rentalDate())
+                        .rentalStartTime(dto.rentalStartTime())
+                        .rentalEndTime(dto.rentalEndTime())
+                        .build()
+                ).toList();
+
+        return rentalRepository.saveAll(rentalsToSave)
+                .stream()
+                .map(RentalRes::from).toList();
+    }
+
+    private boolean invalidDuration(List<ReplaceRental> rentalList) {
+        return rentalList.stream()
+                .anyMatch(dto -> Duration.between(dto.rentalStartTime(), dto.rentalEndTime()).toHours() < 2);
+    }
+
 }

--- a/backend/src/main/java/hyfive/gachita/rental/RentalService.java
+++ b/backend/src/main/java/hyfive/gachita/rental/RentalService.java
@@ -53,7 +53,7 @@ public class RentalService {
                 .map(RentalRes::from).toList();
     }
 
-    public List<RentalRes> getWeeklyRentals(Long carId, LocalDate targetDate) {
+    public List<RentalRes> getRentalList(Long carId, LocalDate targetDate) {
         Car car = carRepository.findById(carId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NO_EXIST_VALUE, "DB에 차량 데이터가 존재하지 않습니다."));
 

--- a/backend/src/main/java/hyfive/gachita/rental/dto/RentalRes.java
+++ b/backend/src/main/java/hyfive/gachita/rental/dto/RentalRes.java
@@ -1,0 +1,39 @@
+package hyfive.gachita.rental.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import hyfive.gachita.rental.Rental;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Schema(description = "유휴 시간 응답 DTO")
+public record RentalRes(
+        @Schema(description = "유휴 시간 ID", example = "1")
+        Long id,
+
+        @Schema(description = "차량 ID", example = "1")
+        Long carId,
+
+        @Schema(description = "유휴 날짜 (yyyy-MM-dd)", example = "2025-08-20")
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate rentalDate,
+
+        @Schema(description = "유휴 시작 시간 (HH:mm)", example = "10:00")
+        @JsonFormat(pattern = "HH:mm")
+        LocalTime rentalStartTime,
+
+        @Schema(description = "유휴 종료 시간 (HH:mm)", example = "14:00")
+        @JsonFormat(pattern = "HH:mm")
+        LocalTime rentalEndTime
+) {
+    public static RentalRes from(Rental rental) {
+        return new RentalRes(
+                rental.getId(),
+                rental.getCar().getId(),
+                rental.getRentalDate(),
+                rental.getRentalStartTime(),
+                rental.getRentalEndTime()
+        );
+    }
+}

--- a/backend/src/main/java/hyfive/gachita/rental/dto/ReplaceRental.java
+++ b/backend/src/main/java/hyfive/gachita/rental/dto/ReplaceRental.java
@@ -1,0 +1,22 @@
+package hyfive.gachita.rental.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Schema(description = "유휴 시간 생성 요청 DTO")
+public record ReplaceRental(
+        @Schema(description = "유휴 날짜 (yyyy-MM-dd)", example = "2025-08-20")
+        @NotNull(message = "유휴 날짜는 필수입니다.")
+        LocalDate rentalDate,
+
+        @Schema(description = "유휴 시작 시간 (HH:mm)", example = "10:00")
+        @NotNull(message = "유휴 시작 시간은 필수입니다.")
+        LocalTime rentalStartTime,
+
+        @Schema(description = "유휴 종료 시간 (HH:mm)", example = "14:00")
+        @NotNull(message = "유휴 종료 시간은 필수입니다.")
+        LocalTime rentalEndTime
+) {}

--- a/backend/src/main/java/hyfive/gachita/rental/repository/CustomRentalRepository.java
+++ b/backend/src/main/java/hyfive/gachita/rental/repository/CustomRentalRepository.java
@@ -1,8 +1,13 @@
 package hyfive.gachita.rental.repository;
 
+import hyfive.gachita.rental.dto.RentalRes;
+
 import java.time.LocalDate;
+import java.util.List;
 
 public interface CustomRentalRepository {
 
     void deleteRentalsBetween(Long carId, LocalDate startDate, LocalDate endDate);
+
+    List<RentalRes> findRentalsBetween(Long carId, LocalDate startDate, LocalDate endDate);
 }

--- a/backend/src/main/java/hyfive/gachita/rental/repository/CustomRentalRepository.java
+++ b/backend/src/main/java/hyfive/gachita/rental/repository/CustomRentalRepository.java
@@ -1,0 +1,8 @@
+package hyfive.gachita.rental.repository;
+
+import java.time.LocalDate;
+
+public interface CustomRentalRepository {
+
+    void deleteRentalsBetween(Long carId, LocalDate startDate, LocalDate endDate);
+}

--- a/backend/src/main/java/hyfive/gachita/rental/repository/CustomRentalRepository.java
+++ b/backend/src/main/java/hyfive/gachita/rental/repository/CustomRentalRepository.java
@@ -1,6 +1,6 @@
 package hyfive.gachita.rental.repository;
 
-import hyfive.gachita.rental.dto.RentalRes;
+import hyfive.gachita.rental.Rental;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -9,5 +9,5 @@ public interface CustomRentalRepository {
 
     void deleteRentalsBetween(Long carId, LocalDate startDate, LocalDate endDate);
 
-    List<RentalRes> findRentalsBetween(Long carId, LocalDate startDate, LocalDate endDate);
+    List<Rental> findRentalsBetween(Long carId, LocalDate startDate, LocalDate endDate);
 }

--- a/backend/src/main/java/hyfive/gachita/rental/repository/CustomRentalRepositoryImpl.java
+++ b/backend/src/main/java/hyfive/gachita/rental/repository/CustomRentalRepositoryImpl.java
@@ -1,11 +1,16 @@
 package hyfive.gachita.rental.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import hyfive.gachita.car.dto.CarListRes;
+import hyfive.gachita.rental.Rental;
+import hyfive.gachita.rental.dto.RentalRes;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.util.List;
 
+import static hyfive.gachita.car.QCar.car;
 import static hyfive.gachita.rental.QRental.rental;
 
 @Repository
@@ -23,5 +28,20 @@ public class CustomRentalRepositoryImpl implements CustomRentalRepository {
                                 .and(rental.rentalDate.between(startDate, endDate))
                 )
                 .execute();
+    }
+
+    @Override
+    public List<RentalRes> findRentalsBetween(Long carId, LocalDate startDate, LocalDate endDate) {
+        List<Rental> rentalList = queryFactory
+                .selectFrom(rental)
+                .where(
+                        rental.car.id.eq(carId)
+                                .and(rental.rentalDate.between(startDate, endDate))
+                )
+                .fetch();
+
+        return rentalList.stream()
+                .map(RentalRes::from)
+                .toList();
     }
 }

--- a/backend/src/main/java/hyfive/gachita/rental/repository/CustomRentalRepositoryImpl.java
+++ b/backend/src/main/java/hyfive/gachita/rental/repository/CustomRentalRepositoryImpl.java
@@ -1,16 +1,13 @@
 package hyfive.gachita.rental.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import hyfive.gachita.car.dto.CarListRes;
 import hyfive.gachita.rental.Rental;
-import hyfive.gachita.rental.dto.RentalRes;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
 import java.util.List;
 
-import static hyfive.gachita.car.QCar.car;
 import static hyfive.gachita.rental.QRental.rental;
 
 @Repository
@@ -31,17 +28,13 @@ public class CustomRentalRepositoryImpl implements CustomRentalRepository {
     }
 
     @Override
-    public List<RentalRes> findRentalsBetween(Long carId, LocalDate startDate, LocalDate endDate) {
-        List<Rental> rentalList = queryFactory
+    public List<Rental> findRentalsBetween(Long carId, LocalDate startDate, LocalDate endDate) {
+        return queryFactory
                 .selectFrom(rental)
                 .where(
                         rental.car.id.eq(carId)
                                 .and(rental.rentalDate.between(startDate, endDate))
                 )
                 .fetch();
-
-        return rentalList.stream()
-                .map(RentalRes::from)
-                .toList();
     }
 }

--- a/backend/src/main/java/hyfive/gachita/rental/repository/CustomRentalRepositoryImpl.java
+++ b/backend/src/main/java/hyfive/gachita/rental/repository/CustomRentalRepositoryImpl.java
@@ -1,0 +1,27 @@
+package hyfive.gachita.rental.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+
+import static hyfive.gachita.rental.QRental.rental;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomRentalRepositoryImpl implements CustomRentalRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public void deleteRentalsBetween(Long carId, LocalDate startDate, LocalDate endDate) {
+        queryFactory
+                .delete(rental)
+                .where(
+                        rental.car.id.eq(carId)
+                                .and(rental.rentalDate.between(startDate, endDate))
+                )
+                .execute();
+    }
+}

--- a/backend/src/main/java/hyfive/gachita/rental/repository/RentalRepository.java
+++ b/backend/src/main/java/hyfive/gachita/rental/repository/RentalRepository.java
@@ -1,0 +1,7 @@
+package hyfive.gachita.rental.repository;
+
+import hyfive.gachita.rental.Rental;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RentalRepository extends JpaRepository<Rental, Long>, CustomRentalRepository {
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Close #122 

## 📝 기능 설명

- 전달받은 car_id, date를 기반으로 유휴 시간 리스트를 조회합니다

## 🛠 작업 사항

### 로직 진행 과정

- car 존재 여부, 2시간 미만 유휴 시간 validation
- targetDate 기준 한 주 기간 조회
- 기간과 carId에 해당하는 모든 유휴시간 조회

### ⚠️ 주의 사항

- #165  PR을 먼저 확인해주세요!

## ✅ 작업 항목
- [x] api 개발
- [x] docs 추가

## 📎 참고 자료
