### PR TITLE
[Refactor/#169] 날짜에 따른 기간 범위 유틸 분리

### DIFF
--- a/backend/src/main/java/hyfive/gachita/book/BookService.java
+++ b/backend/src/main/java/hyfive/gachita/book/BookService.java
@@ -11,12 +11,12 @@ import hyfive.gachita.common.dto.ScrollRes;
 import hyfive.gachita.common.enums.SearchPeriod;
 import hyfive.gachita.common.response.BusinessException;
 import hyfive.gachita.common.response.ErrorCode;
+import hyfive.gachita.common.util.DateRangeUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
 
@@ -65,7 +65,7 @@ public class BookService {
                 limit
         );
 
-        Pair<LocalDateTime, LocalDateTime> dateRange = SearchPeriod.getDateRange(period);
+        Pair<LocalDateTime, LocalDateTime> dateRange = DateRangeUtil.getDateRange(LocalDateTime.now(), period);
         Page<Book> pageResult = bookRepository.searchBookPageByCondition(dateRange, bookStatus, pageable);
 
         List<BookRes> bookResList = pageResult.getContent().stream().map(BookRes::from).toList();

--- a/backend/src/main/java/hyfive/gachita/common/enums/SearchPeriod.java
+++ b/backend/src/main/java/hyfive/gachita/common/enums/SearchPeriod.java
@@ -1,30 +1,8 @@
 package hyfive.gachita.common.enums;
 
-import org.springframework.data.util.Pair;
-
-import java.time.DayOfWeek;
-import java.time.LocalDateTime;
-import java.time.temporal.TemporalAdjusters;
-
 public enum SearchPeriod {
     TODAY,
     YESTERDAY,
     WEEK,
     MONTH;
-
-    public static Pair<LocalDateTime, LocalDateTime> getDateRange(SearchPeriod period) {
-        LocalDateTime today = LocalDateTime.now();
-        return switch (period) {
-            case TODAY -> Pair.of(today, today);
-            case YESTERDAY -> Pair.of(today.minusDays(1), today.minusDays(1));
-            case WEEK -> Pair.of(
-                    today.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY)),
-                    today.with(TemporalAdjusters.nextOrSame(DayOfWeek.SATURDAY))
-            );
-            case MONTH -> Pair.of(
-                    today.withDayOfMonth(1),
-                    today.withDayOfMonth(today.getDayOfMonth())
-            );
-        };
-    }
 }

--- a/backend/src/main/java/hyfive/gachita/common/util/DateRangeUtil.java
+++ b/backend/src/main/java/hyfive/gachita/common/util/DateRangeUtil.java
@@ -27,8 +27,8 @@ public class DateRangeUtil {
                     date.with(TemporalAdjusters.nextOrSame(DayOfWeek.SATURDAY))
             );
             case MONTH -> Pair.of(
-                    date.withDayOfMonth(1),
-                    date.withDayOfMonth(date.getDayOfMonth())
+                    date.with(TemporalAdjusters.firstDayOfMonth()),
+                    date.with(TemporalAdjusters.lastDayOfMonth())
             );
         };
     }

--- a/backend/src/main/java/hyfive/gachita/common/util/DateRangeUtil.java
+++ b/backend/src/main/java/hyfive/gachita/common/util/DateRangeUtil.java
@@ -1,0 +1,25 @@
+package hyfive.gachita.common.util;
+
+import hyfive.gachita.common.enums.SearchPeriod;
+import org.springframework.data.util.Pair;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.temporal.TemporalAdjusters;
+
+public class DateRangeUtil {
+    public static Pair<LocalDateTime, LocalDateTime> getDateRange(LocalDateTime date, SearchPeriod period) {
+        return switch (period) {
+            case TODAY -> Pair.of(date, date);
+            case YESTERDAY -> Pair.of(date.minusDays(1), date.minusDays(1));
+            case WEEK -> Pair.of(
+                    date.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY)),
+                    date.with(TemporalAdjusters.nextOrSame(DayOfWeek.SATURDAY))
+            );
+            case MONTH -> Pair.of(
+                    date.withDayOfMonth(1),
+                    date.withDayOfMonth(date.getDayOfMonth())
+            );
+        };
+    }
+}

--- a/backend/src/main/java/hyfive/gachita/common/util/DateRangeUtil.java
+++ b/backend/src/main/java/hyfive/gachita/common/util/DateRangeUtil.java
@@ -4,11 +4,21 @@ import hyfive.gachita.common.enums.SearchPeriod;
 import org.springframework.data.util.Pair;
 
 import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.temporal.TemporalAdjusters;
 
 public class DateRangeUtil {
     public static Pair<LocalDateTime, LocalDateTime> getDateRange(LocalDateTime date, SearchPeriod period) {
+        Pair<LocalDate, LocalDate> dateRange = getDateRange(date.toLocalDate(), period);
+        return Pair.of(
+                dateRange.getFirst().atStartOfDay(),
+                dateRange.getSecond().atTime(LocalTime.MAX)
+        );
+    }
+
+    public static Pair<LocalDate, LocalDate> getDateRange(LocalDate date, SearchPeriod period) {
         return switch (period) {
             case TODAY -> Pair.of(date, date);
             case YESTERDAY -> Pair.of(date.minusDays(1), date.minusDays(1));

--- a/backend/src/main/java/hyfive/gachita/pay/PayService.java
+++ b/backend/src/main/java/hyfive/gachita/pay/PayService.java
@@ -1,6 +1,7 @@
 package hyfive.gachita.pay;
 
 import hyfive.gachita.common.enums.SearchPeriod;
+import hyfive.gachita.common.util.DateRangeUtil;
 import hyfive.gachita.pay.repository.PayRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.util.Pair;
@@ -14,7 +15,7 @@ public class PayService {
     private final PayRepository payRepository;
 
     public int getWeeklyPayAmount(Long centerId) {
-        Pair<LocalDateTime, LocalDateTime> currentWeekPeriod = SearchPeriod.getDateRange(SearchPeriod.WEEK);
+        Pair<LocalDateTime, LocalDateTime> currentWeekPeriod = DateRangeUtil.getDateRange(LocalDateTime.now(), SearchPeriod.WEEK);
         return payRepository.getAmountByPeriod(centerId, currentWeekPeriod);
     }
 }

--- a/backend/src/main/java/hyfive/gachita/rental/RentalService.java
+++ b/backend/src/main/java/hyfive/gachita/rental/RentalService.java
@@ -2,19 +2,20 @@ package hyfive.gachita.rental;
 
 import hyfive.gachita.car.Car;
 import hyfive.gachita.car.repository.CarRepository;
+import hyfive.gachita.common.enums.SearchPeriod;
 import hyfive.gachita.common.response.BusinessException;
 import hyfive.gachita.common.response.ErrorCode;
+import hyfive.gachita.common.util.DateRangeUtil;
 import hyfive.gachita.rental.dto.ReplaceRental;
 import hyfive.gachita.rental.dto.RentalRes;
 import hyfive.gachita.rental.repository.RentalRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
 
-import java.time.DayOfWeek;
 import java.time.Duration;
 import java.time.LocalDate;
-import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 
 @Service
@@ -33,9 +34,9 @@ public class RentalService {
             throw new BusinessException(ErrorCode.INVALID_DURATION, "유휴시간은 최소 2시간 이상이어야 합니다.");
         }
 
-        // TODO : SearchPeriod 병합되면 유진님과 enum 확장 논의
-        LocalDate startOfWeek = targetDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
-        LocalDate endOfWeek = startOfWeek.plusDays(6);
+        Pair<LocalDate, LocalDate> weekRange = DateRangeUtil.getDateRange(targetDate, SearchPeriod.WEEK);
+        LocalDate startOfWeek = weekRange.getFirst();
+        LocalDate endOfWeek = weekRange.getSecond();
 
         rentalRepository.deleteRentalsBetween(carId, startOfWeek, endOfWeek);
 
@@ -57,9 +58,9 @@ public class RentalService {
         Car car = carRepository.findById(carId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NO_EXIST_VALUE, "DB에 차량 데이터가 존재하지 않습니다."));
 
-        // TODO : SearchPeriod 병합되면 유진님과 enum 확장 논의
-        LocalDate startOfWeek = targetDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
-        LocalDate endOfWeek = startOfWeek.plusDays(6);
+        Pair<LocalDate, LocalDate> weekRange = DateRangeUtil.getDateRange(targetDate, SearchPeriod.WEEK);
+        LocalDate startOfWeek = weekRange.getFirst();
+        LocalDate endOfWeek = weekRange.getSecond();
 
         return rentalRepository.findRentalsBetween(carId, startOfWeek, endOfWeek).stream()
                 .map(RentalRes::from)

--- a/backend/src/test/java/hyfive/gachita/common/util/DataRangeUtilTest.java
+++ b/backend/src/test/java/hyfive/gachita/common/util/DataRangeUtilTest.java
@@ -1,0 +1,92 @@
+package hyfive.gachita.common.util;
+
+import hyfive.gachita.common.enums.SearchPeriod;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.util.Pair;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DateRangeUtilTest {
+
+    // 테스트 기준 날짜 (2025년 8월 12일 화요일)
+    private final LocalDate BASE_DATE = LocalDate.of(2025, 8, 12);
+    private final LocalDateTime BASE_DATE_TIME = BASE_DATE.atTime(10, 30);
+
+    @Test
+    @DisplayName("LocalDate: TODAY를 입력하면 해당 날짜를 그대로 반환한다")
+    void getLocalDateRange_Today() {
+        // when
+        Pair<LocalDate, LocalDate> range = DateRangeUtil.getDateRange(BASE_DATE, SearchPeriod.TODAY);
+
+        // then
+        assertThat(range.getFirst()).isEqualTo(BASE_DATE);
+        assertThat(range.getSecond()).isEqualTo(BASE_DATE);
+    }
+
+    @Test
+    @DisplayName("LocalDate: YESTERDAY를 입력하면 어제 날짜를 반환한다")
+    void getLocalDateRange_Yesterday() {
+        // given
+        LocalDate yesterday = BASE_DATE.minusDays(1);
+
+        // when
+        Pair<LocalDate, LocalDate> range = DateRangeUtil.getDateRange(BASE_DATE, SearchPeriod.YESTERDAY);
+
+        // then
+        assertThat(range.getFirst()).isEqualTo(yesterday);
+        assertThat(range.getSecond()).isEqualTo(yesterday);
+    }
+
+    @Test
+    @DisplayName("LocalDate: WEEK를 입력하면 해당 날짜가 포함된 일요일~토요일을 반환한다")
+    void getLocalDateRange_Week() {
+        // given
+        LocalDate expectedSunday = LocalDate.of(2025, 8, 10);
+        LocalDate expectedSaturday = LocalDate.of(2025, 8, 16);
+
+        // when
+        Pair<LocalDate, LocalDate> range = DateRangeUtil.getDateRange(BASE_DATE, SearchPeriod.WEEK);
+
+        // then
+        assertThat(range.getFirst()).isEqualTo(expectedSunday);
+        assertThat(range.getSecond()).isEqualTo(expectedSaturday);
+    }
+
+    @Test
+    @DisplayName("LocalDate: MONTH를 입력하면 해당 월의 1일과 마지막 날을 반환한다")
+    void getLocalDateRange_Month() {
+        // given
+        LocalDate expectedFirstDay = LocalDate.of(2025, 8, 1);
+        LocalDate expectedLastDay = LocalDate.of(2025, 8, 31);
+
+        // when
+        Pair<LocalDate, LocalDate> range = DateRangeUtil.getDateRange(BASE_DATE, SearchPeriod.MONTH);
+
+        // then
+        assertThat(range.getFirst()).isEqualTo(expectedFirstDay);
+        assertThat(range.getSecond()).isEqualTo(expectedLastDay);
+    }
+
+    @Test
+    @DisplayName("LocalDateTime: 기간을 조회하면 시작일의 00:00:00과 종료일의 23:59:59.999...를 반환한다")
+    void getLocalDateTimeRange() {
+        // given
+        LocalDate firstDayOfMonth = LocalDate.of(2025, 8, 1);
+        LocalDate lastDayOfMonth = LocalDate.of(2025, 8, 31);
+
+        LocalDateTime expectedStart = firstDayOfMonth.atStartOfDay();
+        LocalDateTime expectedEnd = lastDayOfMonth.atTime(LocalTime.MAX);
+
+        // when
+        Pair<LocalDateTime, LocalDateTime> range = DateRangeUtil.getDateRange(BASE_DATE_TIME, SearchPeriod.MONTH);
+
+        // then
+        assertThat(range.getFirst()).isEqualTo(expectedStart);
+        assertThat(range.getSecond()).isEqualTo(expectedEnd);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Close #169 

## 📝 기능 설명
SearchPeriod Enum 내부에 존재하던 날짜에 따른 기간 범위를 구하는 메서드를 유틸 클래스로 분리하였습니다.
해당 기능을 사용하던 rentalService와 bookService 또한 수정하였습니다.

## 🛠 작업 사항
- `LocalDateTime`, `DateTime` 두 가지 타입에 대한 기간을 모두 구해야 하기 때문에, LocalDateTime에 대한 기간은 DateTime의 기간을 구하는 함수를 활용하여 LocalDateTime으로 변환하도록 하였습니다.
- 각 기간에 대한 테스트 함수를 오늘 날짜 기준으로 작성하였습니다.

## ✅ 작업 항목
- [ ] 유틸 메서드 분리 및 적용
- [ ] 테스트코드 작성

## 📎 참고 자료
<!-- 관련 문서, 링크, 스크린샷 등을 첨부해주세요 -->