### PR TITLE
[Feat/#147] 시간표 컴포넌트 내부 유휴시간 블록 구현

### DIFF
--- a/frontend/src/features/Car/CarInfoCard.test.tsx
+++ b/frontend/src/features/Car/CarInfoCard.test.tsx
@@ -1,9 +1,9 @@
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { userEvent } from "@testing-library/user-event";
-import type { CarType } from "@/features/Car/Car.type";
+import type { CarType } from "@/features/car/Car.type";
 import CarImage from "@/assets/images/OriginalCarImg.png";
-import CarInfoCard from "@/features/Car/CarInfoCard";
+import CarInfoCard from "@/features/car/CarInfoCard";
 import { theme } from "@/styles/themes.style";
 import { useState } from "react";
 

--- a/frontend/src/features/Car/CarInfoCard.tsx
+++ b/frontend/src/features/Car/CarInfoCard.tsx
@@ -1,4 +1,4 @@
-import type { CarType } from "@/features/Car/Car.type";
+import type { CarType } from "@/features/car/Car.type";
 import Tag from "@/components/Tag";
 import {
   CardContainer,
@@ -9,7 +9,7 @@ import {
   NameLabel,
   TagSection,
   CarTag,
-} from "@/features/Car/CarInfoCard.style";
+} from "@/features/car/CarInfoCard.style";
 import { CarIcon } from "@/assets/icons";
 import { theme } from "@/styles/themes.style";
 import { useState } from "react";

--- a/frontend/src/features/CenterOverview/CenterInfoCard.tsx
+++ b/frontend/src/features/CenterOverview/CenterInfoCard.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react";
 import { theme } from "@/styles/themes.style";
-import type { CenterInfoCardType } from "@/features/CenterOverview/CenterOverview.type";
+import type { CenterInfoCardType } from "@/features/centerOverview/CenterOverview.type";
 const { color, typography } = theme;
 
 const CenterInfoCard = ({ icon, label, content }: CenterInfoCardType) => {

--- a/frontend/src/features/CenterOverview/CenterOverview.test.tsx
+++ b/frontend/src/features/CenterOverview/CenterOverview.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import type { CenterOverviewType } from "@/features/CenterOverview/CenterOverview.type";
-import CenterOverview from "@/features/CenterOverview/CenterOverview";
-import CenterInfoCard from "@/features/CenterOverview/CenterInfoCard";
+import type { CenterOverviewType } from "@/features/centerOverview/CenterOverview.type";
+import CenterOverview from "@/features/centerOverview/CenterOverview";
+import CenterInfoCard from "@/features/centerOverview/CenterInfoCard";
 import { CallIcon } from "@/assets/icons";
 const mockCenterData: CenterOverviewType = {
   centerName: "남동구 노인 이동 센터",

--- a/frontend/src/features/CenterOverview/CenterOverview.tsx
+++ b/frontend/src/features/CenterOverview/CenterOverview.tsx
@@ -1,9 +1,9 @@
 import { css } from "@emotion/react";
 import { theme } from "@/styles/themes.style";
-import type { CenterOverviewType } from "@/features/CenterOverview/CenterOverview.type";
-import CenterInfoCard from "@/features/CenterOverview/CenterInfoCard";
+import type { CenterOverviewType } from "@/features/centerOverview/CenterOverview.type";
+import CenterInfoCard from "@/features/centerOverview/CenterInfoCard";
 import { CallIcon, CarIcon, LocationIcon, PayIcon } from "@/assets/icons";
-import type { CenterInfoCardType } from "@/features/CenterOverview/CenterOverview.type";
+import type { CenterInfoCardType } from "@/features/centerOverview/CenterOverview.type";
 const { color, typography, borderRadius } = theme;
 
 const CenterOverview = ({

--- a/frontend/src/features/TimeTable/PreviewTimeSlot.tsx
+++ b/frontend/src/features/TimeTable/PreviewTimeSlot.tsx
@@ -1,0 +1,46 @@
+import { getTimeBlockGridStyle } from "@/features/timeTable/TimeTable.style";
+import { css } from "@emotion/react";
+import { theme } from "@/styles/themes.style";
+import { format } from "date-fns";
+
+const { color, typography } = theme;
+
+interface PreviewTimeSlotProps {
+  startPosition: { dayIndex: number; hourIndex: number };
+  endPosition: { dayIndex: number; hourIndex: number };
+  selectedWeek: Date[];
+}
+
+const PreviewTimeSlot = ({
+  startPosition,
+  endPosition,
+  selectedWeek,
+}: PreviewTimeSlotProps) => {
+  const mockSlot = {
+    rentalDate: format(selectedWeek[startPosition.dayIndex], "yyyy-MM-dd"),
+    rentalStartTime: `${9 + startPosition.hourIndex}:00`,
+    rentalEndTime: `${9 + endPosition.hourIndex + 1}:00`,
+  };
+
+  return (
+    <div
+      css={[getTimeBlockGridStyle(mockSlot, selectedWeek), previewBlockStyle]}
+    />
+  );
+};
+
+const previewBlockStyle = css`
+  border-radius: 0 10px 10px 0;
+  margin: 8px;
+  font: ${typography.Label.l4_semi};
+  background: ${color.SemanticScale.orange[100]};
+  border-left: 4px solid ${color.Maincolor.primary};
+  color: ${color.Maincolor.primary};
+
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  pointer-events: none; /* 마우스 이벤트 차단 */
+`;
+
+export default PreviewTimeSlot;

--- a/frontend/src/features/TimeTable/TimeCell.tsx
+++ b/frontend/src/features/TimeTable/TimeCell.tsx
@@ -1,0 +1,31 @@
+import { getTimeCellStyle } from "@/features/timeTable/TimeTable.style";
+
+interface TimeCellProps {
+  hourIndex: number;
+  dayIndex: number;
+  onMouseDown?: () => void;
+  onMouseEnter?: () => void;
+  isPreviewCell: boolean;
+}
+
+const TimeCell = ({
+  hourIndex,
+  dayIndex,
+  onMouseDown,
+  onMouseEnter,
+  isPreviewCell,
+}: TimeCellProps) => {
+  return (
+    <div
+      css={getTimeCellStyle(hourIndex, dayIndex, isPreviewCell)}
+      style={{
+        gridColumn: dayIndex + 2,
+        gridRow: hourIndex + 1,
+      }}
+      onMouseDown={onMouseDown}
+      onMouseEnter={onMouseEnter}
+    />
+  );
+};
+
+export default TimeCell;

--- a/frontend/src/features/TimeTable/TimeTable.style.ts
+++ b/frontend/src/features/TimeTable/TimeTable.style.ts
@@ -49,6 +49,17 @@ export const DateLabel = css`
   margin-bottom: 4px;
 `;
 
+export const getDayLabelStyle = (isToday: boolean) => css`
+  font: ${typography.Body.b4_medi};
+  color: ${isToday ? color.Maincolor.primary : color.GrayScale.gray4};
+`;
+
+export const getDateLabelStyle = (isToday: boolean) => css`
+  font: ${typography.Body.b2_semi};
+  color: ${isToday ? color.Maincolor.primary : color.GrayScale.gray5};
+  margin-bottom: 4px;
+`;
+
 // 바디
 export const TableBody = css`
   flex: 1;
@@ -107,17 +118,6 @@ export const getTimeBlockGridStyle = (
   return css`
     grid-column: ${dayIndex + 2}; /* +2는 시간축(1) + 0-based 인덱스 */
     grid-row: ${startHour - 8} / ${endHour - 8}; /* 9시가 1행이므로 -8 */
-    background: ${color.SemanticScale.orange[100]};
-    border-left: 4px solid ${color.Maincolor.primary};
-    border-radius: 0 10px 10px 0;
-    margin: 8px;
-    padding: 20px;
-    font: ${typography.Label.l4_semi};
-    color: ${color.Maincolor.primary};
     z-index: 10;
-
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
   `;
 };

--- a/frontend/src/features/TimeTable/TimeTable.style.ts
+++ b/frontend/src/features/TimeTable/TimeTable.style.ts
@@ -87,14 +87,27 @@ export const TimeLabel = css`
 export const TimeCell = css`
   border-right: 1px solid ${color.GrayScale.gray3};
   border-bottom: 1px solid ${color.GrayScale.gray3};
+
+  &:hover {
+    background-color: ${color.GrayScale.gray2};
+  }
 `;
 
-export const getTimeCellStyle = (hourIndex: number, dayIndex: number) => {
+export const getTimeCellStyle = (
+  hourIndex: number,
+  dayIndex: number,
+  isPreviewCell: boolean,
+) => {
   const isLastColumn = dayIndex === 6; // 토요일
   const isLastRow = hourIndex === 10; // 19시
 
   return css`
     ${TimeCell}
+    ${isPreviewCell &&
+    css`
+      border-left: 4px solid ${color.Maincolor.primary};
+      background-color: ${color.SemanticScale.orange[100]} !important;
+    `}
     ${isLastColumn &&
     css`
       border-right: none;

--- a/frontend/src/features/TimeTable/TimeTable.style.ts
+++ b/frontend/src/features/TimeTable/TimeTable.style.ts
@@ -1,7 +1,7 @@
 import { css } from "@emotion/react";
 import { theme } from "@/styles/themes.style";
 import { getDayIndex } from "@/features/calender/Calender.util";
-import type { AvailableTimeSlot } from "./TimeTable.type";
+import type { AvailableTimeSlotType } from "./TimeTable.type";
 
 const { color, typography, borderRadius } = theme;
 
@@ -106,7 +106,7 @@ export const getTimeCellStyle = (hourIndex: number, dayIndex: number) => {
   `;
 };
 export const getTimeBlockGridStyle = (
-  block: AvailableTimeSlot,
+  block: AvailableTimeSlotType,
   selectedWeek: Date[],
 ) => {
   const startHour = parseInt(block.rentalStartTime.split(":")[0]);

--- a/frontend/src/features/TimeTable/TimeTable.style.ts
+++ b/frontend/src/features/TimeTable/TimeTable.style.ts
@@ -1,5 +1,7 @@
 import { css } from "@emotion/react";
 import { theme } from "@/styles/themes.style";
+import { getDayIndex } from "@/features/calender/Calender.util";
+import type { AvailableTimeSlot } from "./TimeTable.type";
 
 const { color, typography, borderRadius } = theme;
 
@@ -15,6 +17,7 @@ export const TableContainer = css`
 
 export const TableHeader = css`
   display: grid;
+  height: auto;
   grid-template-columns: 129px repeat(7, 1fr);
   background-color: ${color.GrayScale.gray1};
   border-bottom: 1px solid ${color.GrayScale.gray3};
@@ -52,7 +55,7 @@ export const TableBody = css`
   overflow-y: auto;
   display: grid;
   grid-template-columns: 129px repeat(7, 1fr);
-  grid-template-rows: repeat(11, 46px);
+  grid-template-rows: repeat(11, 1fr);
 `;
 
 export const TimeLabel = css`
@@ -73,18 +76,48 @@ export const TimeLabel = css`
 export const TimeCell = css`
   border-right: 1px solid ${color.GrayScale.gray3};
   border-bottom: 1px solid ${color.GrayScale.gray3};
-
-  &:hover {
-    background-color: ${color.GrayScale.gray1};
-  }
-
-  /* 각 행의 마지막 셀 (일요일) */
-  &:nth-of-type(8n) {
-    border-right: none;
-  }
-
-  /* 마지막 행의 셀 (19시 행) */
-  &:nth-last-of-type(-n + 8) {
-    border-bottom: none;
-  }
 `;
+
+export const getTimeCellStyle = (hourIndex: number, dayIndex: number) => {
+  const isLastColumn = dayIndex === 6; // 토요일
+  const isLastRow = hourIndex === 10; // 19시
+
+  return css`
+    ${TimeCell}
+    ${isLastColumn &&
+    css`
+      border-right: none;
+    `}
+    ${isLastRow &&
+    css`
+      border-bottom: none;
+    `}
+  `;
+};
+export const getTimeBlockGridStyle = (
+  block: AvailableTimeSlot,
+  selectedWeek: Date[],
+) => {
+  const startHour = parseInt(block.rentalStartTime.split(":")[0]);
+  const endHour = parseInt(block.rentalEndTime.split(":")[0]);
+  const dayIndex = getDayIndex(block.rentalDate, selectedWeek);
+
+  if (dayIndex === -1) return css``;
+
+  return css`
+    grid-column: ${dayIndex + 2}; /* +2는 시간축(1) + 0-based 인덱스 */
+    grid-row: ${startHour - 8} / ${endHour - 8}; /* 9시가 1행이므로 -8 */
+    background: ${color.SemanticScale.orange[100]};
+    border-left: 4px solid ${color.Maincolor.primary};
+    border-radius: 0 10px 10px 0;
+    margin: 8px;
+    padding: 20px;
+    font: ${typography.Label.l4_semi};
+    color: ${color.Maincolor.primary};
+    z-index: 10;
+
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+  `;
+};

--- a/frontend/src/features/TimeTable/TimeTable.tsx
+++ b/frontend/src/features/TimeTable/TimeTable.tsx
@@ -9,10 +9,11 @@ import {
   getDateLabelStyle,
   TableBody,
   TimeLabel,
-  getTimeCellStyle,
 } from "./TimeTable.style";
-import { generateAvailableTimeSlots } from "@/mocks/timeBlockMocks";
+import type { AvailableTimeSlotType } from "@/features/TimeTable/TimeTable.type";
 import AvailableTimeSlot from "@/features/availableTimeSlot/AvailableTimeSlot";
+import TimeCell from "@/features/TimeTable/TimeCell";
+import { generateAvailableTimeSlots } from "@/mocks/timeBlockMocks";
 
 interface TimeTableProps {
   selectedCarId: number;
@@ -26,7 +27,8 @@ const TimeTable = ({
   selectedCarId: _selectedCarId,
   selectedWeek,
 }: TimeTableProps) => {
-  const mockAvailableTimes = generateAvailableTimeSlots(selectedWeek);
+  const availableTimeSlots: AvailableTimeSlotType[] =
+    generateAvailableTimeSlots(selectedWeek);
 
   return (
     <div css={TableContainer}>
@@ -64,19 +66,17 @@ const TimeTable = ({
         {/* 시간 셀들 */}
         {Array.from({ length: TOTAL_HOURS }).map((_, hourIndex) =>
           selectedWeek.map((date, dayIndex) => (
-            <div
+            <TimeCell
               key={`${date.toISOString()}-${hourIndex}`}
-              css={getTimeCellStyle(hourIndex, dayIndex)}
-              style={{
-                gridColumn: dayIndex + 2,
-                gridRow: hourIndex + 1,
-              }}
+              hourIndex={hourIndex}
+              dayIndex={dayIndex}
+              date={date}
             />
           )),
         )}
 
         {/* 유휴시간 블록들 */}
-        {mockAvailableTimes.map((block) => (
+        {availableTimeSlots.map((block) => (
           <AvailableTimeSlot
             key={`${block.rentalDate}-${block.rentalStartTime}-${block.rentalEndTime}`}
             block={block}

--- a/frontend/src/features/TimeTable/TimeTable.tsx
+++ b/frontend/src/features/TimeTable/TimeTable.tsx
@@ -10,10 +10,13 @@ import {
   TableBody,
   TimeLabel,
 } from "./TimeTable.style";
-import type { AvailableTimeSlotType } from "@/features/TimeTable/TimeTable.type";
+import type { AvailableTimeSlotType } from "@/features/timeTable/TimeTable.type";
 import AvailableTimeSlot from "@/features/availableTimeSlot/AvailableTimeSlot";
-import TimeCell from "@/features/TimeTable/TimeCell";
+import TimeCell from "@/features/timeTable/TimeCell";
+// import PreviewTimeSlot from "@/features/timeTable/PreviewTimeSlot";
 import { generateAvailableTimeSlots } from "@/mocks/timeBlockMocks";
+import { useTimeTableDrag } from "@/features/timeTable/useTimeTableDrag";
+import { useState } from "react";
 
 interface TimeTableProps {
   selectedCarId: number;
@@ -22,13 +25,24 @@ interface TimeTableProps {
 
 const START_HOUR = 9; // 9시부터
 const TOTAL_HOURS = 11; // 19시까지 총 11칸
-
+const mockWeek: Date[] = Array.from({ length: 7 }, (_, i) => {
+  return new Date(2025, 7, 10 + i);
+});
+const mockTimeSlot: AvailableTimeSlotType[] =
+  generateAvailableTimeSlots(mockWeek);
 const TimeTable = ({
   selectedCarId: _selectedCarId,
   selectedWeek,
 }: TimeTableProps) => {
-  const availableTimeSlots: AvailableTimeSlotType[] =
-    generateAvailableTimeSlots(selectedWeek);
+  const [availableTimeSlots, setAvailableTimeSlots] =
+    useState<AvailableTimeSlotType[]>(mockTimeSlot);
+
+  const { handleCellMouseDown, handleCellMouseEnter, isPreviewCell } =
+    useTimeTableDrag({
+      selectedWeek,
+      availableTimeSlots,
+      onSlotsUpdate: (slots) => setAvailableTimeSlots(slots),
+    });
 
   return (
     <div css={TableContainer}>
@@ -70,7 +84,9 @@ const TimeTable = ({
               key={`${date.toISOString()}-${hourIndex}`}
               hourIndex={hourIndex}
               dayIndex={dayIndex}
-              date={date}
+              onMouseDown={() => handleCellMouseDown(dayIndex, hourIndex)}
+              onMouseEnter={() => handleCellMouseEnter(dayIndex, hourIndex)}
+              isPreviewCell={isPreviewCell(dayIndex, hourIndex)}
             />
           )),
         )}
@@ -83,6 +99,17 @@ const TimeTable = ({
             selectedWeek={selectedWeek}
           />
         ))}
+
+        {/* 드래그 미리보기 */}
+        {/* {dragState.isDragging &&
+          dragState.startPosition &&
+          dragState.currentPosition && (
+            <PreviewTimeSlot
+              startPosition={dragState.startPosition}
+              endPosition={dragState.currentPosition}
+              selectedWeek={selectedWeek}
+            />
+          )} */}
       </div>
     </div>
   );

--- a/frontend/src/features/TimeTable/TimeTable.tsx
+++ b/frontend/src/features/TimeTable/TimeTable.tsx
@@ -9,8 +9,10 @@ import {
   DateLabel,
   TableBody,
   TimeLabel,
-  TimeCell,
+  getTimeBlockGridStyle,
+  getTimeCellStyle,
 } from "./TimeTable.style";
+import { generateAvailableTimeSlots } from "@/mocks/timeBlockMocks";
 
 interface TimeTableProps {
   selectedCarId: number;
@@ -24,6 +26,8 @@ const TimeTable = ({
   selectedCarId: _selectedCarId,
   selectedWeek,
 }: TimeTableProps) => {
+  const mockAvailableTimes = generateAvailableTimeSlots(selectedWeek);
+
   return (
     <div css={TableContainer}>
       <div css={TableHeader}>
@@ -37,19 +41,46 @@ const TimeTable = ({
       </div>
 
       <div css={TableBody}>
+        {/* 시간 레이블들 */}
         {Array.from({ length: TOTAL_HOURS }).map((_, hourIndex) => {
           const hour = START_HOUR + hourIndex;
-          return [
-            // 시간 레이블
-            <div key={`time-label-${hour}`} css={TimeLabel}>
+          return (
+            <div
+              key={`time-label-${hour}`}
+              css={TimeLabel}
+              style={{ gridColumn: 1, gridRow: hourIndex + 1 }}
+            >
               {hour}:00
-            </div>,
-            // 해당 시간의 7개 요일 셀들
-            ...selectedWeek.map((date, _dayIndex) => (
-              <div key={`${date.toISOString()}-${hourIndex}`} css={TimeCell} />
-            )),
-          ];
+            </div>
+          );
         })}
+
+        {/* 시간 셀들 */}
+        {Array.from({ length: TOTAL_HOURS }).map((_, hourIndex) =>
+          selectedWeek.map((date, dayIndex) => (
+            <div
+              key={`${date.toISOString()}-${hourIndex}`}
+              css={getTimeCellStyle(hourIndex, dayIndex)}
+              style={{
+                gridColumn: dayIndex + 2,
+                gridRow: hourIndex + 1,
+              }}
+            />
+          )),
+        )}
+
+        {/* 유휴시간 블록들 */}
+        {mockAvailableTimes.map((block) => (
+          <div
+            key={`${block.rentalDate}-${block.rentalStartTime}-${block.rentalEndTime}`}
+            css={getTimeBlockGridStyle(block, selectedWeek)}
+          >
+            <span>유휴 시간</span>
+            <span>
+              {block.rentalStartTime} ~ {block.rentalEndTime}
+            </span>
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/frontend/src/features/TimeTable/TimeTable.tsx
+++ b/frontend/src/features/TimeTable/TimeTable.tsx
@@ -9,10 +9,10 @@ import {
   DateLabel,
   TableBody,
   TimeLabel,
-  getTimeBlockGridStyle,
   getTimeCellStyle,
 } from "./TimeTable.style";
 import { generateAvailableTimeSlots } from "@/mocks/timeBlockMocks";
+import AvailableTimeSlot from "@/features/availableTimeSlot/AvailableTimeSlot";
 
 interface TimeTableProps {
   selectedCarId: number;
@@ -71,15 +71,11 @@ const TimeTable = ({
 
         {/* 유휴시간 블록들 */}
         {mockAvailableTimes.map((block) => (
-          <div
+          <AvailableTimeSlot
             key={`${block.rentalDate}-${block.rentalStartTime}-${block.rentalEndTime}`}
-            css={getTimeBlockGridStyle(block, selectedWeek)}
-          >
-            <span>유휴 시간</span>
-            <span>
-              {block.rentalStartTime} ~ {block.rentalEndTime}
-            </span>
-          </div>
+            block={block}
+            selectedWeek={selectedWeek}
+          />
         ))}
       </div>
     </div>

--- a/frontend/src/features/TimeTable/TimeTable.tsx
+++ b/frontend/src/features/TimeTable/TimeTable.tsx
@@ -1,12 +1,12 @@
-import { format } from "date-fns";
+import { format, isToday } from "date-fns";
 import { ko } from "date-fns/locale";
 import {
   TableContainer,
   TableHeader,
   TimeAxisPlaceholder,
   DayCell,
-  DayLabel,
-  DateLabel,
+  getDayLabelStyle,
+  getDateLabelStyle,
   TableBody,
   TimeLabel,
   getTimeCellStyle,
@@ -32,12 +32,18 @@ const TimeTable = ({
     <div css={TableContainer}>
       <div css={TableHeader}>
         <div css={TimeAxisPlaceholder} /> {/* 좌측 최상단 빈칸 */}
-        {selectedWeek.map((date) => (
-          <div key={date.toISOString()} css={DayCell}>
-            <div css={DateLabel}>{format(date, "d")}</div>
-            <div css={DayLabel}>{format(date, "E", { locale: ko })}요일</div>
-          </div>
-        ))}
+        {selectedWeek.map((date) => {
+          const todayCheck = isToday(date); // 오늘인지 확인
+
+          return (
+            <div key={date.toISOString()} css={DayCell}>
+              <div css={getDateLabelStyle(todayCheck)}>{format(date, "d")}</div>
+              <div css={getDayLabelStyle(todayCheck)}>
+                {format(date, "E", { locale: ko })}요일
+              </div>
+            </div>
+          );
+        })}
       </div>
 
       <div css={TableBody}>

--- a/frontend/src/features/TimeTable/TimeTable.type.ts
+++ b/frontend/src/features/TimeTable/TimeTable.type.ts
@@ -1,4 +1,4 @@
-export interface AvailableTimeSlot {
+export interface AvailableTimeSlotType {
   rentalDate: string;
   rentalStartTime: string;
   rentalEndTime: string;

--- a/frontend/src/features/TimeTable/TimeTable.type.ts
+++ b/frontend/src/features/TimeTable/TimeTable.type.ts
@@ -1,0 +1,5 @@
+export interface AvailableTimeSlot {
+  rentalDate: string;
+  rentalStartTime: string;
+  rentalEndTime: string;
+}

--- a/frontend/src/features/TimeTable/useTimeTableDrag.ts
+++ b/frontend/src/features/TimeTable/useTimeTableDrag.ts
@@ -1,0 +1,161 @@
+import type { AvailableTimeSlotType } from "@/features/timeTable/TimeTable.type";
+import { format } from "date-fns";
+import { useState, useEffect, useCallback } from "react";
+
+interface DragState {
+  isDragging: boolean;
+  startPosition: { dayIndex: number; hourIndex: number } | null;
+  currentPosition: { dayIndex: number; hourIndex: number } | null;
+}
+
+interface useTimeTableDragProps {
+  selectedWeek: Date[];
+  availableTimeSlots: AvailableTimeSlotType[];
+  onSlotsUpdate?: (slots: AvailableTimeSlotType[]) => void;
+}
+
+export const useTimeTableDrag = ({
+  selectedWeek,
+  availableTimeSlots,
+  onSlotsUpdate,
+}: useTimeTableDragProps) => {
+  const [dragState, setDragState] = useState<DragState>({
+    isDragging: false,
+    startPosition: null,
+    currentPosition: null,
+  });
+
+  const handleCellMouseDown = (dayIndex: number, hourIndex: number) => {
+    if (dragState.isDragging) return;
+
+    // 해당 위치에 이미 슬롯이 있는지 확인
+    const isSlotExists = availableTimeSlots.some((slot) =>
+      isSlotAtPosition(slot, dayIndex, hourIndex, selectedWeek),
+    );
+
+    if (isSlotExists) {
+      // TODO: 이미 슬롯이 있는 경우, 기존 시간을 수정하게끔 구현
+      // 임시로 슬롯이 있는 경우는 드래그를 시작하지 않음
+
+      return;
+    }
+
+    setDragState({
+      isDragging: true,
+      startPosition: { dayIndex, hourIndex },
+      currentPosition: { dayIndex, hourIndex },
+    });
+  };
+
+  const handleCellMouseEnter = (dayIndex: number, hourIndex: number) => {
+    if (!dragState.isDragging) return;
+
+    // 가로 드래그 무시
+    if (dragState.startPosition?.dayIndex !== dayIndex) return;
+
+    // 윗쪽 드래그 무시
+    if (dragState.startPosition?.hourIndex > hourIndex) return;
+
+    // TODO: 이미 데이터 있을 때 처리
+
+    setDragState((prev) => ({
+      ...prev,
+      currentPosition: { dayIndex, hourIndex },
+    }));
+  };
+
+  useEffect(() => {
+    const handleMouseUp = () => {
+      if (
+        dragState.isDragging &&
+        dragState.startPosition &&
+        dragState.currentPosition
+      ) {
+        // 슬롯 추가 함수
+        const newSlot = createSlotFromDrag(
+          dragState.startPosition,
+          dragState.currentPosition,
+          selectedWeek,
+        );
+        const newSlotData = [newSlot, ...availableTimeSlots];
+        onSlotsUpdate?.(newSlotData);
+
+        setDragState({
+          isDragging: false,
+          startPosition: null,
+          currentPosition: null,
+        });
+      }
+    };
+
+    document.addEventListener("mouseup", handleMouseUp);
+    return () => {
+      document.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, [dragState, selectedWeek, availableTimeSlots, onSlotsUpdate]);
+
+  const isPreviewCell = useCallback(
+    (dayIndex: number, hourIndex: number) => {
+      const { isDragging, startPosition, currentPosition } = dragState;
+
+      if (!isDragging || !startPosition || !currentPosition) {
+        return false;
+      }
+
+      return (
+        dayIndex === startPosition.dayIndex &&
+        hourIndex >= startPosition.hourIndex &&
+        hourIndex <= currentPosition.hourIndex
+      );
+    },
+    [dragState],
+  );
+
+  return {
+    // 상태
+    dragState,
+
+    // 핸들러
+    handleCellMouseDown,
+    handleCellMouseEnter,
+
+    // 유틸리티
+    isPreviewCell,
+  };
+};
+
+const isSlotAtPosition = (
+  slot: AvailableTimeSlotType,
+  dayIndex: number,
+  hourIndex: number,
+  selectedWeek: Date[],
+): boolean => {
+  // slot의 날짜 인덱스 찾기
+  const slotDayIndex = selectedWeek.findIndex(
+    (date) => format(date, "yyyy-MM-dd") === slot.rentalDate,
+  );
+
+  const startHour = parseInt(slot.rentalStartTime.split(":")[0], 10);
+  const endHour = parseInt(slot.rentalEndTime.split(":")[0], 10);
+
+  const isInHourRange = hourIndex >= startHour - 9 && hourIndex < endHour - 9; // START_HOUR가 9시이므로 -9
+
+  return slotDayIndex === dayIndex && isInHourRange;
+};
+
+const createSlotFromDrag = (
+  startPosition: { dayIndex: number; hourIndex: number },
+  currentPosition: { dayIndex: number; hourIndex: number },
+  selectedWeek: Date[],
+): AvailableTimeSlotType => {
+  const slotDay = selectedWeek[startPosition.dayIndex];
+  const startHour = startPosition.hourIndex + 9;
+  const endHour = currentPosition.hourIndex + 10; //
+  const rentalDate = format(slotDay, "yyyy-MM-dd");
+
+  return {
+    rentalDate,
+    rentalStartTime: `${startHour.toString().padStart(2, "0")}:00`,
+    rentalEndTime: `${endHour.toString().padStart(2, "0")}:00`,
+  };
+};

--- a/frontend/src/features/availableTimeSlot/AvailableTimeSlot.tsx
+++ b/frontend/src/features/availableTimeSlot/AvailableTimeSlot.tsx
@@ -1,0 +1,20 @@
+import type { AvailableTimeSlot as AvailableTimeSlotType } from "../TimeTable/TimeTable.type";
+import { getTimeBlockGridStyle } from "../TimeTable/TimeTable.style";
+
+interface AvailableTimeSlotProps {
+  block: AvailableTimeSlotType;
+  selectedWeek: Date[];
+}
+
+const AvailableTimeSlot = ({ block, selectedWeek }: AvailableTimeSlotProps) => {
+  return (
+    <div css={getTimeBlockGridStyle(block, selectedWeek)}>
+      <header>유휴 시간</header>
+      <time dateTime={`${block.rentalStartTime}/${block.rentalEndTime}`}>
+        {block.rentalStartTime} ~ {block.rentalEndTime}
+      </time>
+    </div>
+  );
+};
+
+export default AvailableTimeSlot;

--- a/frontend/src/features/availableTimeSlot/AvailableTimeSlot.tsx
+++ b/frontend/src/features/availableTimeSlot/AvailableTimeSlot.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react";
 import { theme } from "@/styles/themes.style";
-import type { AvailableTimeSlot as AvailableTimeSlotType } from "../TimeTable/TimeTable.type";
+import type { AvailableTimeSlotType } from "../TimeTable/TimeTable.type";
 import { getTimeBlockGridStyle } from "../TimeTable/TimeTable.style";
 import { isBefore, startOfDay } from "date-fns";
 

--- a/frontend/src/features/availableTimeSlot/AvailableTimeSlot.tsx
+++ b/frontend/src/features/availableTimeSlot/AvailableTimeSlot.tsx
@@ -1,7 +1,7 @@
 import { css } from "@emotion/react";
 import { theme } from "@/styles/themes.style";
-import type { AvailableTimeSlotType } from "../TimeTable/TimeTable.type";
-import { getTimeBlockGridStyle } from "../TimeTable/TimeTable.style";
+import type { AvailableTimeSlotType } from "../timeTable/TimeTable.type";
+import { getTimeBlockGridStyle } from "../timeTable/TimeTable.style";
 import { isBefore, startOfDay } from "date-fns";
 
 const { color, typography } = theme;
@@ -60,17 +60,6 @@ const PastSlotStyle = css`
   color: ${color.GrayScale.gray4};
 `;
 
-// 수정 모드 스타일 (나중에 사용)
-// const EditModeStyle = css`
-//   cursor: pointer;
-//   transition: all 0.2s ease;
-
-//   &:hover {
-//     transform: translateY(-1px);
-//     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-//   }
-// `;
-
 // 스타일 조합 함수
 const getSlotContainerStyle = (isPastDate: boolean) => {
   const styles = [BaseSlotStyle];
@@ -80,11 +69,5 @@ const getSlotContainerStyle = (isPastDate: boolean) => {
   } else {
     styles.push(ActiveSlotStyle);
   }
-
-  // TODO: 수정모드일 때 EditModeStyle 추가
-  // if (isEditMode) {
-  //   styles.push(EditModeStyle);
-  // }
-
   return styles;
 };

--- a/frontend/src/features/availableTimeSlot/AvailableTimeSlot.tsx
+++ b/frontend/src/features/availableTimeSlot/AvailableTimeSlot.tsx
@@ -1,5 +1,10 @@
+import { css } from "@emotion/react";
+import { theme } from "@/styles/themes.style";
 import type { AvailableTimeSlot as AvailableTimeSlotType } from "../TimeTable/TimeTable.type";
 import { getTimeBlockGridStyle } from "../TimeTable/TimeTable.style";
+import { isBefore, startOfDay } from "date-fns";
+
+const { color, typography } = theme;
 
 interface AvailableTimeSlotProps {
   block: AvailableTimeSlotType;
@@ -7,8 +12,18 @@ interface AvailableTimeSlotProps {
 }
 
 const AvailableTimeSlot = ({ block, selectedWeek }: AvailableTimeSlotProps) => {
+  // 블록 날짜가 오늘보다 이전인지 확인
+  const blockDate = new Date(block.rentalDate);
+  const today = startOfDay(new Date());
+  const isPastDate = isBefore(blockDate, today);
+
   return (
-    <div css={getTimeBlockGridStyle(block, selectedWeek)}>
+    <div
+      css={[
+        getTimeBlockGridStyle(block, selectedWeek),
+        getSlotContainerStyle(isPastDate),
+      ]}
+    >
       <header>유휴 시간</header>
       <time dateTime={`${block.rentalStartTime}/${block.rentalEndTime}`}>
         {block.rentalStartTime} ~ {block.rentalEndTime}
@@ -18,3 +33,58 @@ const AvailableTimeSlot = ({ block, selectedWeek }: AvailableTimeSlotProps) => {
 };
 
 export default AvailableTimeSlot;
+
+// 기본 슬롯 스타일
+const BaseSlotStyle = css`
+  border-radius: 0 10px 10px 0;
+  margin: 8px;
+  padding: 20px;
+  font: ${typography.Label.l4_semi};
+
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+`;
+
+// 현재/미래 날짜 스타일
+const ActiveSlotStyle = css`
+  background: ${color.SemanticScale.orange[100]};
+  border-left: 4px solid ${color.Maincolor.primary};
+  color: ${color.Maincolor.primary};
+`;
+
+// 과거 날짜 스타일
+const PastSlotStyle = css`
+  background: ${color.GrayScale.gray2};
+  border-left: 4px solid ${color.GrayScale.gray4};
+  color: ${color.GrayScale.gray4};
+`;
+
+// 수정 모드 스타일 (나중에 사용)
+// const EditModeStyle = css`
+//   cursor: pointer;
+//   transition: all 0.2s ease;
+
+//   &:hover {
+//     transform: translateY(-1px);
+//     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+//   }
+// `;
+
+// 스타일 조합 함수
+const getSlotContainerStyle = (isPastDate: boolean) => {
+  const styles = [BaseSlotStyle];
+
+  if (isPastDate) {
+    styles.push(PastSlotStyle);
+  } else {
+    styles.push(ActiveSlotStyle);
+  }
+
+  // TODO: 수정모드일 때 EditModeStyle 추가
+  // if (isEditMode) {
+  //   styles.push(EditModeStyle);
+  // }
+
+  return styles;
+};

--- a/frontend/src/features/calender/Calender.util.ts
+++ b/frontend/src/features/calender/Calender.util.ts
@@ -118,3 +118,18 @@ export const checkIsDaySelected = (
 ): boolean => {
   return Boolean(selectedDate && isSelectedDate(day, selectedDate));
 };
+
+/**
+ * 날짜를 문자열로 받아 선택된 주 배열에서 몇 번째 인덱스에 위치하는지 반환합니다.
+ * @param dateString - 비교할 날짜 문자열 (예: "2025-08-01")
+ * @param selectedWeek - 선택된 주 배열
+ * @returns - 날짜 문자열이 포함된 주의 인덱스
+ */
+export const getDayIndex = (
+  dateString: string,
+  selectedWeek: Date[],
+): number => {
+  return selectedWeek.findIndex(
+    (date) => format(date, "yyyy-MM-dd") === dateString,
+  );
+};

--- a/frontend/src/mocks/centerDetailMocks.ts
+++ b/frontend/src/mocks/centerDetailMocks.ts
@@ -1,6 +1,6 @@
 // /admin/centers/:id | /center 에서 사용되는 목데이터
-import type { CenterOverviewType } from "@/features/CenterOverview/CenterOverview.type";
-import type { CarType } from "@/features/Car/Car.type";
+import type { CenterOverviewType } from "@/features/centerOverview/CenterOverview.type";
+import type { CarType } from "@/features/car/Car.type";
 import CarImage from "@/assets/images/OriginalCarImg.png";
 
 export const mockCenterData: CenterOverviewType = {

--- a/frontend/src/mocks/timeBlockMocks.ts
+++ b/frontend/src/mocks/timeBlockMocks.ts
@@ -1,0 +1,46 @@
+import { format } from "date-fns";
+
+export interface AvailableTimeSlot {
+  rentalDate: string;
+  rentalStartTime: string;
+  rentalEndTime: string;
+}
+
+// selectedWeek 기반 간단한 mock 데이터 생성
+export const generateAvailableTimeSlots = (
+  selectedWeek: Date[],
+): AvailableTimeSlot[] => {
+  return [
+    {
+      rentalDate: format(selectedWeek[1], "yyyy-MM-dd"), // 월요일
+      rentalStartTime: "10:00",
+      rentalEndTime: "15:00",
+    },
+    {
+      rentalDate: format(selectedWeek[2], "yyyy-MM-dd"), // 화요일
+      rentalStartTime: "14:00",
+      rentalEndTime: "19:00",
+    },
+
+    {
+      rentalDate: format(selectedWeek[3], "yyyy-MM-dd"), // 수요일
+      rentalStartTime: "11:00",
+      rentalEndTime: "18:00",
+    },
+    {
+      rentalDate: format(selectedWeek[4], "yyyy-MM-dd"), // 목요일
+      rentalStartTime: "09:00",
+      rentalEndTime: "13:00",
+    },
+    {
+      rentalDate: format(selectedWeek[4], "yyyy-MM-dd"), // 목요일
+      rentalStartTime: "16:00",
+      rentalEndTime: "19:00",
+    },
+    {
+      rentalDate: format(selectedWeek[5], "yyyy-MM-dd"), // 금요일
+      rentalStartTime: "15:00",
+      rentalEndTime: "18:00",
+    },
+  ];
+};

--- a/frontend/src/pages/TestPage.tsx
+++ b/frontend/src/pages/TestPage.tsx
@@ -24,8 +24,8 @@ import Input from "@/components/Input";
 import ToggleButton from "@/components/ToggleButton";
 import DropdownInput from "@/components/DropdownInput";
 import Calender from "@/features/calender/Calender";
-import CarInfoCard from "@/features/Car/CarInfoCard";
-import type { CarType } from "@/features/Car/Car.type";
+import CarInfoCard from "@/features/car/CarInfoCard";
+import type { CarType } from "@/features/car/Car.type";
 
 import CarImage from "@/assets/images/OriginalCarImg.png";
 

--- a/frontend/src/pages/admin/centers/CenterDetailPage.tsx
+++ b/frontend/src/pages/admin/centers/CenterDetailPage.tsx
@@ -1,4 +1,4 @@
-import CenterOverview from "@/features/CenterOverview/CenterOverview";
+import CenterOverview from "@/features/centerOverview/CenterOverview";
 import { css } from "@emotion/react";
 import { theme } from "@/styles/themes.style";
 
@@ -6,9 +6,9 @@ const { color, typography } = theme;
 
 import { mockCenterData, mockCarData } from "@/mocks/centerDetailMocks";
 import { useReducer, useState } from "react";
-import CarInfoCard from "@/features/Car/CarInfoCard";
+import CarInfoCard from "@/features/car/CarInfoCard";
 import Calender from "@/features/calender/Calender";
-import TimeTable from "@/features/TimeTable/TimeTable";
+import TimeTable from "@/features/timeTable/TimeTable";
 import {
   calenderReducer,
   initialState,

--- a/frontend/src/pages/admin/centers/CenterDetailPage.tsx
+++ b/frontend/src/pages/admin/centers/CenterDetailPage.tsx
@@ -58,7 +58,7 @@ const CenterDetailPage = () => {
       {/* 타임 테이블 */}
       <div css={SectionWrapper}>
         <h4 css={SectionLabel}>차량 시간표</h4>
-        <div css={ContentSection}>
+        <div css={TableSection}>
           <TimeTable
             selectedCarId={selectedCarId}
             selectedWeek={state.selectedWeek}
@@ -91,7 +91,6 @@ const PageContainer = css`
 const SectionWrapper = css`
   display: flex;
   width: 100%;
-
   flex-direction: column;
   align-items: flex-start;
   gap: 20px;
@@ -108,4 +107,12 @@ const ContentSection = css`
   gap: 20px;
   width: 100%;
   align-items: flex-start;
+`;
+
+const TableSection = css`
+  display: flex;
+  gap: 20px;
+  width: 100%;
+  align-items: flex-start;
+  height: 600px;
 `;


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Close #147 

## 📝 기능 설명
시간표 컴포넌트 위 유휴시간을 나타내는 블록 컴포넌트를 구현했습니다.

## 🛠 작업 사항
기존 시간표가 grid 형식으로 배치되어있기 때문에, 날짜와 시간별로 row / column 값을 계산해서 해당 열 위에 z-index를 줘서 띄워놓았습니다.
이 과정에서 기존 TimeCell이 밀리는 상황이 생겨, 위치를 고정해주는 스타일을 추가했습니다.
- grid-row(가로줄): 시간별로 인덱스를 계산하여 1을 더해줍니다. 첫 인덱스(0)가 9시를 나타내기 때문에 9시라면 인덱스가 1, 10시라면 2 형태로 세로 위치를 고정합니다.
- grid-column(세로줄): 날짜별로 인덱스를 계산하여 2를 더해줍니다. 일요일이면 2, 월요일이면 3 형식으로 가로 위치를 고정합니다. (1은 시간 축 div)

#### `AvailableTimeSlot.tsx`
- 각 유휴시간을 나타내는 블록입니다.
- 날짜, 시작시각, 종료시각 데이터를 가지고 있기 때문에 TimeCell과 마찬가지로 gird row / column을 고정시킬 수 있습니다.
- grid-row(가로줄): 날짜를 토대로 인덱스를 계산하여 2를 더해줍니다. TimeCell과 같은 원리입니다.
- grid-column(세로줄): 시작시각 / 종료시각 형태로 계산됩니다. 9시부터 11시까지라면 1 / 3 형태로, 실제로는 1,2열을 차지합니다.

#### `useTimeTableDrag.ts`
- 드래그앤드롭을 통해 유휴시간을 추가하는 함수입니다. 로직이 복잡할 수 있을 것 같아 노션 페이지에 따로 정리해두었습니다.
- 간단하게 읽어보시고 잘 모르겠다면 편하게 물어봐주세요 ! [개발 일지](https://spiffy-centipede-875.notion.site/24c62570e7c48060913ded02306bd930?source=copy_link)

#### 기타
feature 폴더 내부에 있는 폴더들의 이름을 카멜 케이스로 변경하였습니다.(Car -> car)
센터 세부 페이지에서 시간표와 달력 컴포넌트의 높이를 통일했습니다.
달력 컴포넌트의 월이 변경되어도 헤더의 위치가 항상 동일하도록 변경했습니다.

## ✅ 작업 항목
- [x] 블록 컴포넌트 개발
- [x] 드래그로 추가 가능하도록 구현
- [ ] 삭제 기능 구현

## 📎 참고 자료

https://github.com/user-attachments/assets/b210ded8-82f6-463f-8219-bdaf2e2a0354

[개발 일지](https://spiffy-centipede-875.notion.site/24c62570e7c48060913ded02306bd930?source=copy_link)
