### PR TITLE
[Feat/#178] 차량 등록 폼: 상태 관리 및 유효성 검사

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,14 +14,17 @@
     "test-cli": "vitest"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.1",
     "date-fns": "^4.1.0",
     "eslint-config-prettier": "^10.1.8",
     "prettier": "^3.6.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-error-boundary": "^6.0.0",
+    "react-hook-form": "^7.62.0",
     "react-router": "^7.7.1",
-    "vite-plugin-svgr": "^4.3.0"
+    "vite-plugin-svgr": "^4.3.0",
+    "zod": "^4.0.17"
   },
   "devDependencies": {
     "@emotion/react": "^11.14.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^5.2.1
+        version: 5.2.1(react-hook-form@7.62.0(react@19.1.0))
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -26,12 +29,18 @@ importers:
       react-error-boundary:
         specifier: ^6.0.0
         version: 6.0.0(react@19.1.0)
+      react-hook-form:
+        specifier: ^7.62.0
+        version: 7.62.0(react@19.1.0)
       react-router:
         specifier: ^7.7.1
         version: 7.7.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       vite-plugin-svgr:
         specifier: ^4.3.0
         version: 4.3.0(rollup@4.46.1)(typescript@5.8.3)(vite@7.0.6(@types/node@24.1.0)(tsx@4.20.3))
+      zod:
+        specifier: ^4.0.17
+        version: 4.0.17
     devDependencies:
       '@emotion/react':
         specifier: ^11.14.0
@@ -459,6 +468,11 @@ packages:
     resolution: {integrity: sha512-Ul5l+lHEcw3L5+k8POx6r74mxEYKG5kOb6Xpy2gCRW6zweT6TEhAf8vhxGgjhqrd/VO/Dirhsb+1hNpD1ue9hw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@hookform/resolvers@5.2.1':
+    resolution: {integrity: sha512-u0+6X58gkjMcxur1wRWokA7XsiiBJ6aK17aPZxhkoYiK5J+HcTx0Vhu9ovXe6H+dVpO6cjrn2FkJTryXEMlryQ==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -618,6 +632,9 @@ packages:
     resolution: {integrity: sha512-7GVB4luhFmGUNXXJhH2jJwZCFB3pIOixv2E3s17GQHBFUOQaISlt7aGcQgqvCaDSxTZJUzlK/QJ1FN8S94MrzQ==}
     cpu: [x64]
     os: [win32]
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0':
     resolution: {integrity: sha512-b9MIk7yhdS1pMCZM8VeNfUlSKVRhsHZNMl5O9SfaX0l0t5wjdgu4IDzGB8bpnGBBOjGST3rRFVsaaEtI4W6f7g==}
@@ -1505,6 +1522,12 @@ packages:
     peerDependencies:
       react: '>=16.13.1'
 
+  react-hook-form@7.62.0:
+    resolution: {integrity: sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -1871,6 +1894,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod@4.0.17:
+    resolution: {integrity: sha512-1PHjlYRevNxxdy2JZ8JcNAw7rX8V9P1AKkP+x/xZfxB0K5FYfuV+Ug6P/6NVSR2jHQ+FzDDoDHS04nYUsOIyLQ==}
+
 snapshots:
 
   '@adobe/css-tools@4.4.3': {}
@@ -2208,6 +2234,11 @@ snapshots:
       '@eslint/core': 0.15.1
       levn: 0.4.1
 
+  '@hookform/resolvers@5.2.1(react-hook-form@7.62.0(react@19.1.0))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.62.0(react@19.1.0)
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.6':
@@ -2318,6 +2349,8 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.46.1':
     optional: true
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.28.0)':
     dependencies:
@@ -3257,6 +3290,10 @@ snapshots:
       '@babel/runtime': 7.28.2
       react: 19.1.0
 
+  react-hook-form@7.62.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
@@ -3592,3 +3629,5 @@ snapshots:
   yaml@1.10.2: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@4.0.17: {}

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -28,6 +28,7 @@ const Button = ({
       type={type}
       {...handlers}
       css={ButtonContainer(bgColor, size, isPressing)}
+      disabled={bgColor === "gray"}
     >
       {label}
     </button>

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -10,17 +10,27 @@ interface ButtonProps {
   label: string;
   bgColor?: Color;
   size?: Size;
+  type?: "submit" | "button" | "reset";
 }
 
-const Button = ({ label, bgColor = "orange", size = "small" }: ButtonProps) => {
+const Button = ({
+  label,
+  bgColor = "orange",
+  size = "small",
+  type = "button",
+}: ButtonProps) => {
   const [isPressing, setIsPressing] = useState(false);
   const handlers = usePressDetection({
     setIsPressing,
   });
   return (
-    <div {...handlers} css={ButtonContainer(bgColor, size, isPressing)}>
+    <button
+      type={type}
+      {...handlers}
+      css={ButtonContainer(bgColor, size, isPressing)}
+    >
       {label}
-    </div>
+    </button>
   );
 };
 

--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -28,7 +28,6 @@ const Button = ({
       type={type}
       {...handlers}
       css={ButtonContainer(bgColor, size, isPressing)}
-      disabled={bgColor === "gray"}
     >
       {label}
     </button>

--- a/frontend/src/components/DropdownInput.tsx
+++ b/frontend/src/components/DropdownInput.tsx
@@ -11,9 +11,9 @@ interface DropdownInputProps {
   required?: boolean;
   requiredLabel?: string;
   placeholder?: string;
-  options: string[] | number[];
-  value: string | number;
-  onSelect?: (value: string | number) => void;
+  options: string[];
+  value: string;
+  onSelect?: (value: string) => void;
 }
 
 const DropdownInput = ({
@@ -28,7 +28,7 @@ const DropdownInput = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const [isOpen, setIsOpen] = useState(false);
 
-  const handleSelect = (option: string | number) => {
+  const handleSelect = (option: string) => {
     onSelect?.(option);
     setIsOpen(false);
   };

--- a/frontend/src/components/DropdownInput.tsx
+++ b/frontend/src/components/DropdownInput.tsx
@@ -11,9 +11,9 @@ interface DropdownInputProps {
   required?: boolean;
   requiredLabel?: string;
   placeholder?: string;
-  options: string[];
-  value: string;
-  onSelect?: (value: string) => void;
+  options: string[] | number[];
+  value: string | number;
+  onSelect?: (value: string | number) => void;
 }
 
 const DropdownInput = ({
@@ -28,7 +28,7 @@ const DropdownInput = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const [isOpen, setIsOpen] = useState(false);
 
-  const handleSelect = (option: string) => {
+  const handleSelect = (option: string | number) => {
     onSelect?.(option);
     setIsOpen(false);
   };

--- a/frontend/src/components/DropdownInput.tsx
+++ b/frontend/src/components/DropdownInput.tsx
@@ -14,6 +14,7 @@ interface DropdownInputProps {
   options: string[];
   value: string;
   onSelect?: (value: string) => void;
+  errorMessage?: string;
 }
 
 const DropdownInput = ({
@@ -24,6 +25,7 @@ const DropdownInput = ({
   options,
   value,
   onSelect,
+  errorMessage,
 }: DropdownInputProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [isOpen, setIsOpen] = useState(false);
@@ -64,6 +66,7 @@ const DropdownInput = ({
         onClick={() => setIsOpen((prev) => !prev)}
         icon={isOpen ? <ChevronUpIcon /> : <ChevronDownIcon />}
         value={value}
+        errorMessage={errorMessage}
       />
       {isOpen && (
         <ul css={DropdownList}>

--- a/frontend/src/components/Input.tsx
+++ b/frontend/src/components/Input.tsx
@@ -12,9 +12,10 @@ interface InputProps {
   icon?: React.ReactNode;
   placeholder?: string;
   readOnly?: boolean;
-  value?: string | number;
+  value?: string;
   onClick?: () => void;
   register?: UseFormRegisterReturn;
+  errorMessage?: string;
 }
 
 const Input = ({
@@ -27,6 +28,7 @@ const Input = ({
   readOnly = false,
   onClick,
   register,
+  errorMessage = "",
 }: InputProps) => {
   const [isFocused, setIsFocused] = useState(false);
   return (
@@ -42,7 +44,7 @@ const Input = ({
       </div>
       <div css={InputWrapper}>
         <input
-          css={StyledInput(isFocused, readOnly)}
+          css={StyledInput(isFocused, readOnly, errorMessage)}
           type="text"
           placeholder={placeholder}
           onFocus={() => setIsFocused(true)}
@@ -54,6 +56,7 @@ const Input = ({
         />
         {icon && <span css={IconWrapper}>{icon}</span>}
       </div>
+      {errorMessage && <p css={ErrorText}>{errorMessage}</p>}
     </div>
   );
 };
@@ -104,7 +107,16 @@ const IconWrapper = css`
   right: 24px;
 `;
 
-const StyledInput = (isFocused: boolean, readOnly: boolean) => css`
+const ErrorText = css`
+  font: ${typography.Body.b4_regu};
+  color: ${color.Semantic.error};
+`;
+
+const StyledInput = (
+  isFocused: boolean,
+  readOnly: boolean,
+  errorMessage: string,
+) => css`
   box-sizing: border-box;
   display: flex;
   width: 100%;
@@ -113,7 +125,11 @@ const StyledInput = (isFocused: boolean, readOnly: boolean) => css`
   font: ${typography.Body.b3_regu};
   color: ${color.GrayScale.black};
   border: 1px solid
-    ${isFocused ? color.Maincolor.primary : color.GrayScale.gray3};
+    ${errorMessage
+      ? color.Semantic.error
+      : isFocused
+        ? color.Maincolor.primary
+        : color.GrayScale.gray3};
   border-radius: ${borderRadius.Medium};
   cursor: ${readOnly ? "pointer" : "text"};
   &::placeholder {

--- a/frontend/src/components/Input.tsx
+++ b/frontend/src/components/Input.tsx
@@ -51,7 +51,7 @@ const Input = ({
           onFocus={() => setIsFocused(true)}
           onBlur={(e) => {
             setIsFocused(false);
-            rhfOnBlur(e); //onBlur 덮어쓰기 문제 해결 위한 이벤트 병합
+            void rhfOnBlur(e); //onBlur 덮어쓰기 문제 해결 위한 이벤트 병합
           }}
           readOnly={readOnly}
           onClick={onClick}

--- a/frontend/src/components/Input.tsx
+++ b/frontend/src/components/Input.tsx
@@ -128,15 +128,16 @@ const StyledInput = (
   padding: 16px 48px 16px 24px;
   font: ${typography.Body.b3_regu};
   color: ${color.GrayScale.black};
-  border: 1px solid
-    ${errorMessage
-      ? color.Semantic.error
-      : isFocused
-        ? color.Maincolor.primary
-        : color.GrayScale.gray3};
+  border: 1px solid ${getBorderColor(errorMessage, isFocused)};
   border-radius: ${borderRadius.Medium};
   cursor: ${readOnly ? "pointer" : "text"};
   &::placeholder {
     color: ${color.GrayScale.gray4};
   }
 `;
+
+function getBorderColor(errorMessage: string, isFocused: boolean) {
+  if (errorMessage) return color.Semantic.error;
+  if (isFocused) return color.Maincolor.primary;
+  return color.GrayScale.gray3;
+}

--- a/frontend/src/components/Input.tsx
+++ b/frontend/src/components/Input.tsx
@@ -1,6 +1,7 @@
 import { css } from "@emotion/react";
 import { theme } from "@/styles/themes.style";
 import { useState } from "react";
+import type { UseFormRegisterReturn } from "react-hook-form";
 
 const { color, typography, borderRadius } = theme;
 
@@ -11,8 +12,9 @@ interface InputProps {
   icon?: React.ReactNode;
   placeholder?: string;
   readOnly?: boolean;
-  value?: string;
+  value?: string | number;
   onClick?: () => void;
+  register?: UseFormRegisterReturn;
 }
 
 const Input = ({
@@ -24,6 +26,7 @@ const Input = ({
   value,
   readOnly = false,
   onClick,
+  register,
 }: InputProps) => {
   const [isFocused, setIsFocused] = useState(false);
   return (
@@ -47,6 +50,7 @@ const Input = ({
           readOnly={readOnly}
           onClick={onClick}
           value={value}
+          {...register}
         />
         {icon && <span css={IconWrapper}>{icon}</span>}
       </div>

--- a/frontend/src/components/Input.tsx
+++ b/frontend/src/components/Input.tsx
@@ -31,6 +31,7 @@ const Input = ({
   errorMessage = "",
 }: InputProps) => {
   const [isFocused, setIsFocused] = useState(false);
+  const { onBlur: rhfOnBlur = () => {}, ...restRegister } = register || {};
   return (
     <div css={InputContainer}>
       <div css={LabelContainer}>
@@ -48,11 +49,14 @@ const Input = ({
           type="text"
           placeholder={placeholder}
           onFocus={() => setIsFocused(true)}
-          onBlur={() => setIsFocused(false)}
+          onBlur={(e) => {
+            setIsFocused(false);
+            rhfOnBlur(e); //onBlur 덮어쓰기 문제 해결 위한 이벤트 병합
+          }}
           readOnly={readOnly}
           onClick={onClick}
           value={value}
-          {...register}
+          {...restRegister}
         />
         {icon && <span css={IconWrapper}>{icon}</span>}
       </div>

--- a/frontend/src/components/ToggleButton.tsx
+++ b/frontend/src/components/ToggleButton.tsx
@@ -19,7 +19,11 @@ const ToggleButton = ({
   onToggle,
 }: ToggleButtonProps) => {
   return (
-    <button css={ButtonContainer(type, isChecked)} onClick={onToggle}>
+    <button
+      type="button"
+      css={ButtonContainer(type, isChecked)}
+      onClick={onToggle}
+    >
       <p css={StyledLabel(isChecked)}>{label}</p>
       {type === "check" &&
         (isChecked ? (

--- a/frontend/src/features/carUploader/InputSection.tsx
+++ b/frontend/src/features/carUploader/InputSection.tsx
@@ -25,8 +25,7 @@ const InputSection = () => {
   return (
     <form
       css={InputSectionContainer}
-      onSubmit={handleSubmit((e) => {
-        console.log(e);
+      onSubmit={handleSubmit(() => {
         reset();
       })}
     >

--- a/frontend/src/features/carUploader/InputSection.tsx
+++ b/frontend/src/features/carUploader/InputSection.tsx
@@ -6,15 +6,39 @@ import { css } from "@emotion/react";
 import OriginCarImg from "@/assets/images/OriginalCarImg.png";
 import Button from "@/components/Button";
 import { Controller, useForm } from "react-hook-form";
+import z from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
 
 const InputSection = () => {
-  const dropdownOptions = Array.from({ length: 5 }, (_, index) => index + 1);
+  const dropdownOptions = Array.from({ length: 5 }, (_, index) =>
+    String(index + 1),
+  );
+  const carSchema = z
+    .object({
+      carModel: z.string().min(1, "필수 입력값입니다"),
+      carNumber: z
+        .string()
+        .refine((value) => /^\d{2,3}[가-힣]\d{4}$/.test(value), {
+          message: "올바른 차량 번호 형식이 아닙니다 (예: 12가3456)",
+        }),
+      maxPassenger: z.string().refine((value) => value !== "", {
+        message: "필수 입력값입니다",
+      }),
+      isLowFloor: z.boolean(),
+    })
+    .refine((data) => data.carModel);
 
-  const { register, control, handleSubmit } = useForm({
+  const {
+    register,
+    control,
+    handleSubmit,
+    formState: { errors },
+  } = useForm({
+    resolver: zodResolver(carSchema),
     defaultValues: {
       carModel: "",
       carNumber: "",
-      maxPassenger: 0,
+      maxPassenger: "",
       isLowFloor: false,
     },
   });
@@ -31,6 +55,7 @@ const InputSection = () => {
         placeholder="모델명을 입력해주세요"
         readOnly={false}
         register={register("carModel", { required: true })}
+        errorMessage={errors.carModel?.message}
       />
       <Input
         label={"차량 번호"}
@@ -38,6 +63,7 @@ const InputSection = () => {
         placeholder="차량 번호를 입력해주세요"
         readOnly={false}
         register={register("carNumber", { required: true })}
+        errorMessage={errors.carNumber?.message}
       />
       <Controller
         name="maxPassenger"
@@ -51,6 +77,7 @@ const InputSection = () => {
             options={dropdownOptions}
             value={field.value}
             onSelect={(value) => field.onChange(value)}
+            errorMessage={errors.maxPassenger?.message}
           />
         )}
       />

--- a/frontend/src/features/carUploader/InputSection.tsx
+++ b/frontend/src/features/carUploader/InputSection.tsx
@@ -14,20 +14,18 @@ const InputSection = () => {
   const dropdownOptions = Array.from({ length: MAX_PASSENGER }, (_, index) =>
     String(index + 1),
   );
-  const carSchema = z
-    .object({
-      carModel: z.string().min(1, "필수 입력값입니다"),
-      carNumber: z
-        .string()
-        .refine((value) => /^\d{2,3}[가-힣]\d{4}$/.test(value), {
-          message: "올바른 차량 번호 형식이 아닙니다 (예: 12가3456)",
-        }),
-      maxPassenger: z.string().refine((value) => value !== "", {
-        message: "필수 입력값입니다",
+  const carSchema = z.object({
+    carModel: z.string().min(1, "필수 입력값입니다"),
+    carNumber: z
+      .string()
+      .refine((value) => /^\d{2,3}[가-힣]\d{4}$/.test(value), {
+        message: "올바른 차량 번호 형식이 아닙니다 (예: 12가3456)",
       }),
-      isLowFloor: z.boolean(),
-    })
-    .refine((data) => data.carModel);
+    maxPassenger: z.string().refine((value) => value !== "", {
+      message: "필수 입력값입니다",
+    }),
+    isLowFloor: z.boolean(),
+  });
 
   const {
     register,

--- a/frontend/src/features/carUploader/InputSection.tsx
+++ b/frontend/src/features/carUploader/InputSection.tsx
@@ -4,43 +4,72 @@ import ToggleButton from "@/components/ToggleButton";
 import ImageInput from "@/features/carUploader/ImageInput";
 import { css } from "@emotion/react";
 import OriginCarImg from "@/assets/images/OriginalCarImg.png";
+import Button from "@/components/Button";
+import { Controller, useForm } from "react-hook-form";
 
 const InputSection = () => {
-  const dropdownOptions = Array.from({ length: 5 }, (_, index) =>
-    String(index + 1),
-  );
+  const dropdownOptions = Array.from({ length: 5 }, (_, index) => index + 1);
+
+  const { register, control, handleSubmit } = useForm({
+    defaultValues: {
+      carModel: "",
+      carNumber: "",
+      maxPassenger: 0,
+      isLowFloor: false,
+    },
+  });
 
   return (
-    <div css={InputSectionContainer}>
+    <form
+      css={InputSectionContainer}
+      onSubmit={handleSubmit((e) => console.log(e))}
+    >
       <ImageInput imageSrc={OriginCarImg} />
       <Input
         label={"모델명"}
         required={true}
         placeholder="모델명을 입력해주세요"
         readOnly={false}
+        register={register("carModel", { required: true })}
       />
       <Input
         label={"차량 번호"}
         required={true}
         placeholder="차량 번호를 입력해주세요"
         readOnly={false}
+        register={register("carNumber", { required: true })}
       />
-      <DropdownInput
-        label="최대탑승 인원"
-        required={true}
-        requiredLabel="운전자 제외"
-        placeholder="인원"
-        options={dropdownOptions}
-        value={""}
-        onSelect={() => {}}
+      <Controller
+        name="maxPassenger"
+        control={control}
+        render={({ field }) => (
+          <DropdownInput
+            label="최대탑승 인원"
+            required={true}
+            requiredLabel="운전자 제외"
+            placeholder="인원"
+            options={dropdownOptions}
+            value={field.value}
+            onSelect={(value) => field.onChange(value)}
+          />
+        )}
       />
-      <ToggleButton
-        type="check"
-        label="저상형"
-        isChecked={true}
-        onToggle={() => {}}
+      <Controller
+        name="isLowFloor"
+        control={control}
+        render={({ field }) => (
+          <ToggleButton
+            type="check"
+            label="저상형"
+            isChecked={field.value}
+            onToggle={() => {
+              field.onChange(!field.value);
+            }}
+          />
+        )}
       />
-    </div>
+      <Button type="submit" bgColor="gray" label="등록하기" size="big" />
+    </form>
   );
 };
 

--- a/frontend/src/features/carUploader/InputSection.tsx
+++ b/frontend/src/features/carUploader/InputSection.tsx
@@ -33,9 +33,10 @@ const InputSection = () => {
     register,
     control,
     handleSubmit,
+    reset,
     formState: { errors, isValid },
   } = useForm({
-    mode: "all",
+    mode: "onSubmit",
     resolver: zodResolver(carSchema),
     defaultValues: {
       carModel: "",
@@ -48,7 +49,10 @@ const InputSection = () => {
   return (
     <form
       css={InputSectionContainer}
-      onSubmit={handleSubmit((e) => console.log(e))}
+      onSubmit={handleSubmit((e) => {
+        console.log(e);
+        reset();
+      })}
     >
       <ImageInput imageSrc={OriginCarImg} />
       <Input

--- a/frontend/src/features/carUploader/InputSection.tsx
+++ b/frontend/src/features/carUploader/InputSection.tsx
@@ -5,27 +5,14 @@ import ImageInput from "@/features/carUploader/ImageInput";
 import { css } from "@emotion/react";
 import OriginCarImg from "@/assets/images/OriginalCarImg.png";
 import Button from "@/components/Button";
-import { Controller, useForm } from "react-hook-form";
-import z from "zod";
-import { zodResolver } from "@hookform/resolvers/zod";
+import { Controller } from "react-hook-form";
+import useCarForm from "@/features/carUploader/useCarForm";
 
 const InputSection = () => {
   const MAX_PASSENGER = 25;
   const dropdownOptions = Array.from({ length: MAX_PASSENGER }, (_, index) =>
     String(index + 1),
   );
-  const carSchema = z.object({
-    carModel: z.string().min(1, "필수 입력값입니다"),
-    carNumber: z
-      .string()
-      .refine((value) => /^\d{2,3}[가-힣]\d{4}$/.test(value), {
-        message: "올바른 차량 번호 형식이 아닙니다 (예: 12가3456)",
-      }),
-    maxPassenger: z.string().refine((value) => value !== "", {
-      message: "필수 입력값입니다",
-    }),
-    isLowFloor: z.boolean(),
-  });
 
   const {
     register,
@@ -33,16 +20,7 @@ const InputSection = () => {
     handleSubmit,
     reset,
     formState: { errors, isValid },
-  } = useForm({
-    mode: "onSubmit",
-    resolver: zodResolver(carSchema),
-    defaultValues: {
-      carModel: "",
-      carNumber: "",
-      maxPassenger: "",
-      isLowFloor: false,
-    },
-  });
+  } = useCarForm();
 
   return (
     <form

--- a/frontend/src/features/carUploader/InputSection.tsx
+++ b/frontend/src/features/carUploader/InputSection.tsx
@@ -10,7 +10,8 @@ import z from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 
 const InputSection = () => {
-  const dropdownOptions = Array.from({ length: 5 }, (_, index) =>
+  const MAX_PASSENGER = 25;
+  const dropdownOptions = Array.from({ length: MAX_PASSENGER }, (_, index) =>
     String(index + 1),
   );
   const carSchema = z
@@ -32,8 +33,9 @@ const InputSection = () => {
     register,
     control,
     handleSubmit,
-    formState: { errors },
+    formState: { errors, isValid },
   } = useForm({
+    mode: "all",
     resolver: zodResolver(carSchema),
     defaultValues: {
       carModel: "",
@@ -95,7 +97,12 @@ const InputSection = () => {
           />
         )}
       />
-      <Button type="submit" bgColor="gray" label="등록하기" size="big" />
+      <Button
+        type="submit"
+        bgColor={isValid ? "orange" : "gray"}
+        label="등록하기"
+        size="big"
+      />
     </form>
   );
 };

--- a/frontend/src/features/carUploader/useCarForm.ts
+++ b/frontend/src/features/carUploader/useCarForm.ts
@@ -1,0 +1,33 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import z from "zod";
+
+const useCarForm = () => {
+  const carSchema = z.object({
+    carModel: z.string().min(1, "필수 입력값입니다"),
+    carNumber: z
+      .string()
+      .refine((value) => /^\d{2,3}[가-힣]\d{4}$/.test(value), {
+        message: "올바른 차량 번호 형식이 아닙니다 (예: 12가3456)",
+      }),
+    maxPassenger: z.string().refine((value) => value !== "", {
+      message: "필수 입력값입니다",
+    }),
+    isLowFloor: z.boolean(),
+  });
+
+  const { register, control, handleSubmit, reset, formState } = useForm({
+    mode: "onSubmit",
+    resolver: zodResolver(carSchema),
+    defaultValues: {
+      carModel: "",
+      carNumber: "",
+      maxPassenger: "",
+      isLowFloor: false,
+    },
+  });
+
+  return { register, control, handleSubmit, reset, formState };
+};
+
+export default useCarForm;

--- a/frontend/src/features/carUploader/useCarForm.ts
+++ b/frontend/src/features/carUploader/useCarForm.ts
@@ -1,6 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
-import z from "zod";
+import { z } from "zod";
 
 const useCarForm = () => {
   const carSchema = z.object({

--- a/frontend/src/features/carUploader/useCarForm.ts
+++ b/frontend/src/features/carUploader/useCarForm.ts
@@ -2,20 +2,18 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
-const useCarForm = () => {
-  const carSchema = z.object({
-    carModel: z.string().min(1, "필수 입력값입니다"),
-    carNumber: z
-      .string()
-      .refine((value) => /^\d{2,3}[가-힣]\d{4}$/.test(value), {
-        message: "올바른 차량 번호 형식이 아닙니다 (예: 12가3456)",
-      }),
-    maxPassenger: z.string().refine((value) => value !== "", {
-      message: "필수 입력값입니다",
-    }),
-    isLowFloor: z.boolean(),
-  });
+const carSchema = z.object({
+  carModel: z.string().min(1, "필수 입력값입니다"),
+  carNumber: z.string().refine((value) => /^\d{2,3}[가-힣]\d{4}$/.test(value), {
+    message: "올바른 차량 번호 형식이 아닙니다 (예: 12가3456)",
+  }),
+  maxPassenger: z.string().refine((value) => value !== "", {
+    message: "필수 입력값입니다",
+  }),
+  isLowFloor: z.boolean(),
+});
 
+const useCarForm = () => {
   const { register, control, handleSubmit, reset, formState } = useForm({
     mode: "onSubmit",
     resolver: zodResolver(carSchema),

--- a/frontend/src/pages/center/CenterRegisterPage.tsx
+++ b/frontend/src/pages/center/CenterRegisterPage.tsx
@@ -1,6 +1,5 @@
 import { css } from "@emotion/react";
 import { theme } from "@/styles/themes.style";
-import Button from "@/components/Button";
 import InputSection from "@/features/carUploader/InputSection";
 
 const { typography } = theme;
@@ -10,7 +9,6 @@ const CenterRegisterPage = () => {
     <div css={CenterRegisterPageContainer}>
       <p css={HeaderText}>차량 등록하기</p>
       <InputSection />
-      <Button bgColor="gray" label="등록하기" size="big" />
     </div>
   );
 };

--- a/frontend/src/pages/center/CenterRegisterPage.tsx
+++ b/frontend/src/pages/center/CenterRegisterPage.tsx
@@ -20,7 +20,8 @@ const CenterRegisterPageContainer = css`
   flex-direction: column;
   gap: 44px;
   max-width: 660px;
-  margin: 44px auto;
+  margin: 0 auto;
+  padding: 40px 0;
 `;
 
 const HeaderText = css`


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Close #178 

## 📝 기능 설명
차량 등록 폼에서 상태 관리 및 유효성 검사를 진행했습니다.

더불어 개발 일지에 진행 과정을 작성해두었습니다! 
📝  [차량 등록: react-hook-form+zod로 편리하게!](https://spiffy-centipede-875.notion.site/hook-form-zod-24d62570e7c480e8956ae78b0a5dad1d)

## 🛠 작업 사항
### react-hook-form: Register VS Controller 함수
#### 목적
- Register 함수: 비제어 인풋과 결합 → 리렌더 최소화로 효율성 확보
- Controller 함수: 커스텀 컴포넌트와 결합 → 코드 가독성 확보
#### 프로젝트에서 적용
- input이 존재하지 않는 커스텀 컴포넌트: Controller 함수 사용
- input이 존재하는 커스텀 컴포넌트: Register 함수 사용

### Register 함수의 onBlur가 Input의 onBlur를 덮어씌우는 현상 해결
기존 Input에 onBlur가 존재했으나, Register를 등록한 순간부터 덮어쓰게 되며 기능 자체가 동작을 하지 않았습니다. 해당 문제를 해결하기 위해 이벤트 병합을 진행했습니다. 

Input의 onBlur 내부에 Register의 onBlur를 함께 실행하는 방법을 선택했습니다.
```tsx
const Input = ({ register }: InputProps) => {
  const { onBlur: rhfOnBlur = () => {}, ...restRegister } = register || {};
  return (
    <div css={InputContainer}>
      <input
        onBlur={(e) => {
          setIsFocused(false);
          rhfOnBlur(e); //onBlur 덮어쓰기 문제 해결 위한 이벤트 병합
        }}
        {...restRegister}
      />
    </div>
  );
};

```

## ✅ 작업 항목
- [x] react-hook-form, zod 설치
- [x] react-hook-form으로 상태 관리
- [x] zod로 유효성 검사
- [x] 유효성 검사시 에러 메시지 출력
- [x] 유효성 통과시 제출 및 폼 초기화


## 📎 참고 자료
### 유효성 검사에 실패한 경우
<img width="1721" height="945" alt="스크린샷 2025-08-13 오전 12 49 44" src="https://github.com/user-attachments/assets/008d3010-9f91-4f2e-9031-91ae2d9f3480" />

### 유효성 검사에 성공한 경우
<img width="1719" height="951" alt="스크린샷 2025-08-13 오전 12 50 35" src="https://github.com/user-attachments/assets/3d0c3416-5326-4fa2-9ede-a9ed74c1f7ac" />

