### PR TITLE
[Feat/#89] S3 이미지 등록 기능 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -43,6 +43,9 @@ dependencies {
 	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	// s3
+	implementation 'io.awspring.cloud:spring-cloud-aws-s3:3.4.0'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/hyfive/gachita/car/CarService.java
+++ b/backend/src/main/java/hyfive/gachita/car/CarService.java
@@ -21,6 +21,7 @@ import static hyfive.gachita.common.util.CarNumberFormatter.normalize;
 public class CarService {
     private final CarRepository carRepository;
     private final CenterRepository centerRepository;
+    private final S3Service s3Service;
 
     public Car createCar(CreateCarReq createCarReq){
         Center center = centerRepository.findById(createCarReq.centerId())
@@ -36,8 +37,7 @@ public class CarService {
             throw new BusinessException(ErrorCode.DUPLICATE_CAR_NUMBER);
         }
 
-        // TODO : 이미지 저장 service 개발 필요
-        String imageUrl = "test";
+        String imageUrl = s3Service.uploadImage(createCarReq.imageFile());
 
         // 엔티티 생성
         Car car = Car.builder()
@@ -62,8 +62,7 @@ public class CarService {
             throw new BusinessException(ErrorCode.DUPLICATE_CAR_NUMBER);
         }
 
-        // TODO : 이미지 저장 service 개발 필요 - 기존 사진 덮어 쓰기
-        String imageUrl = "test_change";
+        String imageUrl = s3Service.uploadImage(updateCarReq.imageFile());
 
         car.update(
                 updateCarReq.modelName(),

--- a/backend/src/main/java/hyfive/gachita/car/S3Service.java
+++ b/backend/src/main/java/hyfive/gachita/car/S3Service.java
@@ -1,0 +1,108 @@
+package hyfive.gachita.car;
+
+import hyfive.gachita.common.response.BusinessException;
+import hyfive.gachita.common.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetUrlRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class S3Service {
+
+    @Value("${spring.cloud.aws.s3.bucket:defaultBucket}")
+    private String bucketName;
+    private final S3Client s3Client;
+
+    private final String BASE_PATH = "images/";
+    private final long MAX_FILE_SIZE = 10 * 1024 * 1024;
+
+    public String uploadImage(MultipartFile file) {
+        try {
+            validateFile(file);
+
+            String key = getKey(file.getOriginalFilename());
+
+            // 객체 업로드
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .contentType(file.getContentType())
+                    .build();
+
+            s3Client.putObject(
+                    putObjectRequest,
+                    RequestBody.fromInputStream(file.getInputStream(), file.getSize())
+            );
+
+            // url 반환
+            GetUrlRequest getUrlRequest = GetUrlRequest.builder()
+                    .bucket(bucketName)
+                    .key(key)
+                    .build();
+            return s3Client.utilities().getUrl(getUrlRequest).toString();
+
+        }  catch (IOException e) {
+            log.error("S3 업로드 중 IOException 발생", e);
+            throw new BusinessException(ErrorCode.S3_UPLOAD_FAILED);
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("S3 업로드 중 알 수 없는 예외 발생", e);
+            throw new BusinessException(ErrorCode.S3_UPLOAD_FAILED);
+        }
+    }
+
+    private void validateFile(MultipartFile file) {
+        if (file == null || file.isEmpty() || file.getSize() <= 0) {
+            log.error("파일이 비어있거나 크기가 0 이하입니다.");
+            throw new BusinessException(ErrorCode.EMPTY_FILE);
+        }
+
+        if (file.getSize() > MAX_FILE_SIZE) {
+            log.error("파일 크기 초과: {} bytes", file.getSize());
+            throw new BusinessException(ErrorCode.MAX_UPLOAD_SIZE_EXCEEDED);
+        }
+
+        String extension = getExtension(file.getOriginalFilename());
+        if (!isAllowedExtension(extension)) {
+            log.error("허용되지 않은 확장자: {}", extension);
+            throw new BusinessException(ErrorCode.FILE_TYPE_NOT_ALLOWED);
+        }
+    }
+
+    private boolean isAllowedExtension(String extension) {
+        String[] allowed = {"jpg", "jpeg", "png", "gif", "webp"};
+        for (String allow : allowed) {
+            if (allow.equalsIgnoreCase(extension)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String getKey(String fileName) {
+        String key = UUID.randomUUID().toString();
+        String extension = getExtension(fileName);
+        if (extension.isEmpty()) {
+            extension = "bin";  // 기본 확장자 지정
+        }
+        return BASE_PATH + key + "." +  extension;
+    }
+
+    private String getExtension(String filename) {
+        if (filename == null || !filename.contains(".")) return "";
+        return filename.substring(filename.lastIndexOf(".") + 1);
+    }
+}
+

--- a/backend/src/main/java/hyfive/gachita/common/response/ErrorCode.java
+++ b/backend/src/main/java/hyfive/gachita/common/response/ErrorCode.java
@@ -34,6 +34,7 @@ public enum ErrorCode {
     MAX_UPLOAD_SIZE_EXCEEDED(false, 3005, "파일 사이즈는 최대 10MB 까지 업로드 할 수 있습니다.",
             MaxUploadSizeExceededException.class
     ),
+    S3_UPLOAD_FAILED(false, 3006, "S3 업로드 중 알 수 없는 예외 발생"),
 
     /*차량 4500*/
     MAX_CAR_COUNT_EXCEEDED(false, 4500, "등록 가능한 최대 차량 수는 6대 입니다."),

--- a/backend/src/main/java/hyfive/gachita/common/response/ErrorCode.java
+++ b/backend/src/main/java/hyfive/gachita/common/response/ErrorCode.java
@@ -28,7 +28,7 @@ public enum ErrorCode {
     /*서버, DB, s3 3000*/
     DATABASE_ERROR(false, 3000, "DB에 문제가 발생했습니다."),
     NO_EXIST_VALUE(false, 3001, "DB에 데이터가 존재하지 않습니다."),
-    EMPTY_FILE(false, 3002, "S3 업로드 실패 - 빈 파일을 주셨습니다."),
+    EMPTY_FILE(false, 3002, "빈 파일 입니다."),
     FILE_TYPE_NOT_ALLOWED(false, 3003, "허용되지 않은 확장자 입니다."),
     FILE_DELETE_FAIL(false, 3004, "S3 이미지 삭제에 실패했습니다."),
     MAX_UPLOAD_SIZE_EXCEEDED(false, 3005, "파일 사이즈는 최대 10MB 까지 업로드 할 수 있습니다.",

--- a/backend/src/main/java/hyfive/gachita/config/S3Config.java
+++ b/backend/src/main/java/hyfive/gachita/config/S3Config.java
@@ -1,0 +1,21 @@
+package hyfive.gachita.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Value("${spring.cloud.aws.region.static:defaultRegion}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .build();
+    }
+}

--- a/backend/src/main/resources/application-init.properties
+++ b/backend/src/main/resources/application-init.properties
@@ -49,4 +49,3 @@ geocode.api.key=${GEOCODE_API_KEY}
 # S3
 spring.cloud.aws.region.static=${AWS_REGION}
 spring.cloud.aws.s3.bucket=${BUCKET_NAME}
-aws.s3.base-url=${S3_BASE_URL}

--- a/backend/src/main/resources/application-init.properties
+++ b/backend/src/main/resources/application-init.properties
@@ -45,3 +45,8 @@ spring.servlet.multipart.max-request-size=10MB
 # api
 geocode.api.base-url=${GEOCODE_API_BASE_URL}
 geocode.api.key=${GEOCODE_API_KEY}
+
+# S3
+spring.cloud.aws.region.static=${AWS_REGION}
+spring.cloud.aws.s3.bucket=${BUCKET_NAME}
+aws.s3.base-url=${S3_BASE_URL}

--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -31,3 +31,8 @@ spring.servlet.multipart.max-request-size=10MB
 # api
 geocode.api.base-url=${GEOCODE_API_BASE_URL}
 geocode.api.key=${GEOCODE_API_KEY}
+
+# S3
+spring.cloud.aws.region.static=${AWS_REGION}
+spring.cloud.aws.s3.bucket=${BUCKET_NAME}
+aws.s3.base-url=${S3_BASE_URL}

--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -35,4 +35,3 @@ geocode.api.key=${GEOCODE_API_KEY}
 # S3
 spring.cloud.aws.region.static=${AWS_REGION}
 spring.cloud.aws.s3.bucket=${BUCKET_NAME}
-aws.s3.base-url=${S3_BASE_URL}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Close #89 

## 📝 기능 설명

S3와 연동하여`/images` 경로에 이미지를 업로드하는 기능입니다.

#### [사용처]
- 차량 등록
- 차량 수정

## 🛠 작업 사항
### 의존성
```java
io.awspring.cloud:spring-cloud-aws-s3:3.4.0
```

### 이미지 공개 범위
- 기본 설정 : public-read
- 제한 사항 : `http://d1llms5eo9o356.cloudfront.net` 도메인에서만 read 가능하도록 제한

### S3 관련 예외 처리 사항
Enum | Code | Message
-- | -- | --
EMPTY_FILE | 3002 | 빈 파일 입니다.
FILE_TYPE_NOT_ALLOWED | 3003 | 허용되지 않은 확장자 입니다.
MAX_UPLOAD_SIZE_EXCEEDED | 3005 | 파일 사이즈는 최대 10MB 까지 업로드 할 수 있습니다.
S3_UPLOAD_FAILED | 3006 | S3 업로드 중 알 수 없는 예외 발생

### 테스트 사항
- 배포 환경에서 이미지 업로드 테스트 완료
- 배포 환경에서 이미지 FE 화면에 띄우기 테스트 완료

### 변동 사항
- cloudfront에서만 접근 가능하도록 설정하는데 실패했습니다
- 이에 따라 이미지는 상기 작성된 바와 같이 public-read로 정책을 작성했습니다. (AWS S3 console permissions 탭 참조)
- 해당 사항은 qa 이슈로 등록해두었습니다 #187 

### 리뷰 요청 사항
1. S3Service의 위치는 car package 아래 두는 것이 적절할까요?
  - 이미지 업로드는 차량에서만 사용해서, common은 아니라고 판단되어 우선 이곳에 두었습니다.
2. 이미지 삭제 기능이 필요할까요?
  - 차량 삭제 혹은 차량 수정시, 안 쓰게 된 사진을 S3에서 삭제하는 로직을 추가하는게 좋을까요? (비용문제)
  - 만약 필요하다고 판단된다면, 이슈 생성 후 진행하겠습니다.
  
## ✅ 작업 항목
- [x] S3 연동
- [x] Car에 S3 이미지 업로드 기능 추가
- [x] 배포 환경 테스트 진행

## 📎 참고 자료
