### PR TITLE
[Feat/#194] 시간표 컴포넌트 모드 추가

### DIFF
--- a/frontend/src/features/timeTable/TimeTable.style.ts
+++ b/frontend/src/features/timeTable/TimeTable.style.ts
@@ -1,7 +1,7 @@
 import { css } from "@emotion/react";
 import { theme } from "@/styles/themes.style";
 import { getDayIndex } from "@/features/calender/Calender.util";
-import type { AvailableTimeSlotType } from "./TimeTable.type";
+import type { AvailableTimeSlotType, TimeTableMode } from "./TimeTable.type";
 import { TIME_TABLE_CONFIG } from "@/features/timeTable/TimeTable.constants";
 
 const { color, typography, borderRadius } = theme;
@@ -91,7 +91,7 @@ export const TimeCell = css`
 `;
 
 export const getTimeCellStyle = (
-  mode: "view" | "edit",
+  mode: TimeTableMode,
   hourIndex: number,
   dayIndex: number,
   isPreviewCell: boolean,

--- a/frontend/src/features/timeTable/TimeTable.style.ts
+++ b/frontend/src/features/timeTable/TimeTable.style.ts
@@ -88,13 +88,10 @@ export const TimeLabel = css`
 export const TimeCell = css`
   border-right: 1px solid ${color.GrayScale.gray3};
   border-bottom: 1px solid ${color.GrayScale.gray3};
-
-  &:hover {
-    background-color: ${color.GrayScale.gray2};
-  }
 `;
 
 export const getTimeCellStyle = (
+  mode: "view" | "edit",
   hourIndex: number,
   dayIndex: number,
   isPreviewCell: boolean,
@@ -104,6 +101,13 @@ export const getTimeCellStyle = (
 
   return css`
     ${TimeCell}
+    ${mode === "edit" &&
+    css`
+      cursor: pointer;
+      &:hover {
+        background-color: ${color.GrayScale.gray2};
+      }
+    `}
     ${isPreviewCell &&
     css`
       border-left: 4px solid ${color.Maincolor.primary};

--- a/frontend/src/features/timeTable/TimeTable.test.tsx
+++ b/frontend/src/features/timeTable/TimeTable.test.tsx
@@ -2,10 +2,15 @@ import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import TimeTable from "./components/TimeTable";
 import { getWeekRange } from "@/features/calender/Calender.util";
+import type { TimeTableProps } from "@/features/timeTable/TimeTable.type";
+import { format } from "date-fns";
+import type { AvailableTimeSlot } from "@/mocks/timeBlockMocks";
+import { isAllSlotsInSelectedWeek } from "@/features/timeTable/TimeTable.util";
 
-const testData = {
+const testData: TimeTableProps = {
   selectedCarId: 1,
   selectedWeek: getWeekRange(new Date("2025-08-13")),
+  mode: "view",
 };
 
 describe("TimeTable 컴포넌트", () => {
@@ -42,5 +47,76 @@ describe("TimeTable 컴포넌트", () => {
     expect(screen.getByText("16")).toBeInTheDocument();
 
     expect(screen.queryByText("17")).not.toBeInTheDocument();
+  });
+});
+
+export const mockSelectedWeek: Date[] = [
+  new Date("2025-08-10"), // 일요일
+  new Date("2025-08-11"), // 월요일
+  new Date("2025-08-12"), // 화요일
+  new Date("2025-08-13"), // 수요일
+  new Date("2025-08-14"), // 목요일
+  new Date("2025-08-15"), // 금요일
+  new Date("2025-08-16"), // 토요일
+];
+const mockTimeSlotData: AvailableTimeSlot[] = [
+  {
+    rentalDate: format(new Date("2025-08-10"), "yyyy-MM-dd"), // 일요일
+    rentalStartTime: "10:00",
+    rentalEndTime: "15:00",
+  },
+  {
+    rentalDate: format(new Date("2025-08-11"), "yyyy-MM-dd"), // 월요일
+    rentalStartTime: "09:00",
+    rentalEndTime: "12:00",
+  },
+  {
+    rentalDate: format(new Date("2025-08-11"), "yyyy-MM-dd"), // 월요일
+    rentalStartTime: "14:00",
+    rentalEndTime: "18:00",
+  },
+  {
+    rentalDate: format(new Date("2025-08-12"), "yyyy-MM-dd"), // 화요일
+    rentalStartTime: "10:00",
+    rentalEndTime: "16:00",
+  },
+  {
+    rentalDate: format(new Date("2025-08-13"), "yyyy-MM-dd"), // 수요일
+    rentalStartTime: "11:00",
+    rentalEndTime: "13:00",
+  },
+  {
+    rentalDate: format(new Date("2025-08-13"), "yyyy-MM-dd"), // 수요일
+    rentalStartTime: "15:00",
+    rentalEndTime: "19:00",
+  },
+  {
+    rentalDate: format(new Date("2025-08-14"), "yyyy-MM-dd"), // 목요일
+    rentalStartTime: "09:00",
+    rentalEndTime: "11:00",
+  },
+];
+
+describe("TimeTable.util.ts", () => {
+  it("isAllSlotsInSelectedWeek 함수가 모든 슬롯이 선택된 주에 포함되는지 확인한다.", () => {
+    const result = isAllSlotsInSelectedWeek(mockTimeSlotData, mockSelectedWeek);
+    expect(result).toBe(true);
+  });
+
+  it("isAllSlotsInSelectedWeek 함수가 일부 슬롯이 선택된 주에 포함되지 않으면 false를 반환한다.", () => {
+    const invalidSlots: AvailableTimeSlot[] = [
+      {
+        rentalDate: format(new Date("2025-08-14"), "yyyy-MM-dd"), // 목요일
+        rentalStartTime: "09:00",
+        rentalEndTime: "11:00",
+      },
+      {
+        rentalDate: "2025-08-17", // 토요일, 선택된 주에 없음
+        rentalStartTime: "10:00",
+        rentalEndTime: "12:00",
+      },
+    ];
+    const result = isAllSlotsInSelectedWeek(invalidSlots, mockSelectedWeek);
+    expect(result).toBe(false);
   });
 });

--- a/frontend/src/features/timeTable/TimeTable.type.ts
+++ b/frontend/src/features/timeTable/TimeTable.type.ts
@@ -17,5 +17,7 @@ export interface CellPosition {
 export interface TimeTableProps {
   selectedCarId: number;
   selectedWeek: Date[];
-  mode: "view" | "edit";
+  mode: TimeTableMode;
 }
+
+export type TimeTableMode = "view" | "edit";

--- a/frontend/src/features/timeTable/TimeTable.type.ts
+++ b/frontend/src/features/timeTable/TimeTable.type.ts
@@ -17,4 +17,5 @@ export interface CellPosition {
 export interface TimeTableProps {
   selectedCarId: number;
   selectedWeek: Date[];
+  mode: "view" | "edit";
 }

--- a/frontend/src/features/timeTable/TimeTable.util.ts
+++ b/frontend/src/features/timeTable/TimeTable.util.ts
@@ -1,3 +1,4 @@
+import type { AvailableTimeSlotType } from "@/features/timeTable/TimeTable.type";
 import { format, isSameDay } from "date-fns";
 import { ko } from "date-fns/locale";
 
@@ -36,4 +37,19 @@ export const formatDayOfWeek = (date: Date): string => {
  */
 export const formatHourWithColons = (hour: number): string => {
   return `${hour}:00`;
+};
+
+/**
+ * 배열의 모든 데이터의 날짜가 selectedWeek의 날짜에 포함되는지 확인합니다.
+ * @param slots 확인할 시간 슬롯 배열
+ * @param selectedWeek 선택된 주의 날짜 배열
+ * @returns 모든 슬롯이 선택된 주에 포함되면 true, 아니면 false
+ */
+export const isAllSlotsInSelectedWeek = (
+  slots: AvailableTimeSlotType[],
+  selectedWeek: Date[],
+): boolean => {
+  const formattedWeek = selectedWeek.map((date) => format(date, "yyyy-MM-dd"));
+
+  return slots.every((slot) => formattedWeek.includes(slot.rentalDate));
 };

--- a/frontend/src/features/timeTable/components/TimeCell.tsx
+++ b/frontend/src/features/timeTable/components/TimeCell.tsx
@@ -1,9 +1,10 @@
 import { getTimeCellStyle } from "@/features/timeTable/TimeTable.style";
+import type { TimeTableMode } from "@/features/timeTable/TimeTable.type";
 
 interface TimeCellProps {
   hourIndex: number;
   dayIndex: number;
-  mode: "view" | "edit";
+  mode: TimeTableMode;
   onMouseDown?: () => void;
   onMouseEnter?: () => void;
   isPreviewCell: boolean;

--- a/frontend/src/features/timeTable/components/TimeCell.tsx
+++ b/frontend/src/features/timeTable/components/TimeCell.tsx
@@ -7,7 +7,7 @@ interface TimeCellProps {
   mode: TimeTableMode;
   onMouseDown?: () => void;
   onMouseEnter?: () => void;
-  isPreviewCell: boolean;
+  isPreviewCell?: boolean;
 }
 
 const TimeCell = ({
@@ -16,7 +16,7 @@ const TimeCell = ({
   dayIndex,
   onMouseDown,
   onMouseEnter,
-  isPreviewCell,
+  isPreviewCell = false,
 }: TimeCellProps) => {
   return (
     <div

--- a/frontend/src/features/timeTable/components/TimeCell.tsx
+++ b/frontend/src/features/timeTable/components/TimeCell.tsx
@@ -22,8 +22,8 @@ const TimeCell = ({
     <div
       css={getTimeCellStyle(mode, hourIndex, dayIndex, isPreviewCell)}
       style={{
-        gridColumn: dayIndex + 2,
-        gridRow: hourIndex + 1,
+        gridColumn: dayIndex + 1 + 1, // grid 인덱스 보정 + 시간 축 컬럼
+        gridRow: hourIndex + 1, // grid 인덱스 보정
       }}
       onMouseDown={onMouseDown}
       onMouseEnter={onMouseEnter}

--- a/frontend/src/features/timeTable/components/TimeCell.tsx
+++ b/frontend/src/features/timeTable/components/TimeCell.tsx
@@ -3,12 +3,14 @@ import { getTimeCellStyle } from "@/features/timeTable/TimeTable.style";
 interface TimeCellProps {
   hourIndex: number;
   dayIndex: number;
+  mode: "view" | "edit";
   onMouseDown?: () => void;
   onMouseEnter?: () => void;
   isPreviewCell: boolean;
 }
 
 const TimeCell = ({
+  mode,
   hourIndex,
   dayIndex,
   onMouseDown,
@@ -17,7 +19,7 @@ const TimeCell = ({
 }: TimeCellProps) => {
   return (
     <div
-      css={getTimeCellStyle(hourIndex, dayIndex, isPreviewCell)}
+      css={getTimeCellStyle(mode, hourIndex, dayIndex, isPreviewCell)}
       style={{
         gridColumn: dayIndex + 2,
         gridRow: hourIndex + 1,

--- a/frontend/src/features/timeTable/components/TimeCells.tsx
+++ b/frontend/src/features/timeTable/components/TimeCells.tsx
@@ -6,9 +6,9 @@ interface TimeCellsProps {
   totalHours: number;
   selectedWeek: Date[];
   mode: TimeTableMode;
-  handleCellMouseDown: (dayIndex: number, hourIndex: number) => void;
-  handleCellMouseEnter: (dayIndex: number, hourIndex: number) => void;
-  isPreviewCell: (dayIndex: number, hourIndex: number) => boolean;
+  handleCellMouseDown?: (dayIndex: number, hourIndex: number) => void;
+  handleCellMouseEnter?: (dayIndex: number, hourIndex: number) => void;
+  isPreviewCell?: (dayIndex: number, hourIndex: number) => boolean;
 }
 
 const TimeCells = ({
@@ -43,9 +43,9 @@ const TimeCells = ({
           mode={mode}
           hourIndex={hourIndex}
           dayIndex={dayIndex}
-          onMouseDown={() => handleCellMouseDown(dayIndex, hourIndex)}
-          onMouseEnter={() => handleCellMouseEnter(dayIndex, hourIndex)}
-          isPreviewCell={isPreviewCell(dayIndex, hourIndex)}
+          onMouseDown={() => handleCellMouseDown?.(dayIndex, hourIndex)}
+          onMouseEnter={() => handleCellMouseEnter?.(dayIndex, hourIndex)}
+          isPreviewCell={!!isPreviewCell?.(dayIndex, hourIndex)}
         />
       ))}
     </>

--- a/frontend/src/features/timeTable/components/TimeCells.tsx
+++ b/frontend/src/features/timeTable/components/TimeCells.tsx
@@ -4,6 +4,7 @@ import { memo, useMemo } from "react";
 interface TimeCellsProps {
   totalHours: number;
   selectedWeek: Date[];
+  mode: "view" | "edit";
   handleCellMouseDown: (dayIndex: number, hourIndex: number) => void;
   handleCellMouseEnter: (dayIndex: number, hourIndex: number) => void;
   isPreviewCell: (dayIndex: number, hourIndex: number) => boolean;
@@ -12,6 +13,7 @@ interface TimeCellsProps {
 const TimeCells = ({
   totalHours,
   selectedWeek,
+  mode,
   handleCellMouseDown,
   handleCellMouseEnter,
   isPreviewCell,
@@ -37,6 +39,7 @@ const TimeCells = ({
       {cells.map(({ key, hourIndex, dayIndex }) => (
         <TimeCell
           key={key}
+          mode={mode}
           hourIndex={hourIndex}
           dayIndex={dayIndex}
           onMouseDown={() => handleCellMouseDown(dayIndex, hourIndex)}

--- a/frontend/src/features/timeTable/components/TimeCells.tsx
+++ b/frontend/src/features/timeTable/components/TimeCells.tsx
@@ -1,10 +1,11 @@
 import TimeCell from "@/features/timeTable/components/TimeCell";
+import type { TimeTableMode } from "@/features/timeTable/TimeTable.type";
 import { memo, useMemo } from "react";
 
 interface TimeCellsProps {
   totalHours: number;
   selectedWeek: Date[];
-  mode: "view" | "edit";
+  mode: TimeTableMode;
   handleCellMouseDown: (dayIndex: number, hourIndex: number) => void;
   handleCellMouseEnter: (dayIndex: number, hourIndex: number) => void;
   isPreviewCell: (dayIndex: number, hourIndex: number) => boolean;

--- a/frontend/src/features/timeTable/components/TimeTable.tsx
+++ b/frontend/src/features/timeTable/components/TimeTable.tsx
@@ -6,7 +6,7 @@ import type {
 
 import { generateAvailableTimeSlots } from "@/mocks/timeBlockMocks";
 import { useTimeTableDrag } from "@/features/timeTable/useTimeTableDrag";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   AvailableTimeSlots,
   TimeTableHeader,
@@ -14,12 +14,14 @@ import {
   TimeCells,
 } from "./index";
 import { TIME_TABLE_CONFIG } from "@/features/timeTable/TimeTable.constants";
+import { isAllSlotsInSelectedWeek } from "@/features/timeTable/TimeTable.util";
 
 const mockWeek: Date[] = Array.from({ length: 7 }, (_, i) => {
   return new Date(2025, 7, 10 + i);
 });
 const mockTimeSlot: AvailableTimeSlotType[] =
   generateAvailableTimeSlots(mockWeek);
+
 const TimeTable = ({
   selectedCarId: _selectedCarId,
   selectedWeek,
@@ -27,6 +29,15 @@ const TimeTable = ({
 }: TimeTableProps) => {
   const [availableTimeSlots, setAvailableTimeSlots] =
     useState<AvailableTimeSlotType[]>(mockTimeSlot);
+
+  useEffect(() => {
+    const TimeSlot = generateAvailableTimeSlots(selectedWeek);
+    setAvailableTimeSlots(TimeSlot);
+  }, [selectedWeek]);
+  const canRenderSlots = isAllSlotsInSelectedWeek(
+    availableTimeSlots,
+    selectedWeek,
+  );
 
   const { handleCellMouseDown, handleCellMouseEnter, isPreviewCell } =
     useTimeTableDrag({
@@ -60,10 +71,12 @@ const TimeTable = ({
         />
 
         {/* 유휴시간 블록들 - TimeCell 위 블록*/}
-        <AvailableTimeSlots
-          availableTimeData={availableTimeSlots}
-          selectedWeek={selectedWeek}
-        />
+        {canRenderSlots && (
+          <AvailableTimeSlots
+            availableTimeData={availableTimeSlots}
+            selectedWeek={selectedWeek}
+          />
+        )}
       </div>
     </div>
   );

--- a/frontend/src/features/timeTable/components/TimeTable.tsx
+++ b/frontend/src/features/timeTable/components/TimeTable.tsx
@@ -23,12 +23,14 @@ const mockTimeSlot: AvailableTimeSlotType[] =
 const TimeTable = ({
   selectedCarId: _selectedCarId,
   selectedWeek,
+  mode,
 }: TimeTableProps) => {
   const [availableTimeSlots, setAvailableTimeSlots] =
     useState<AvailableTimeSlotType[]>(mockTimeSlot);
 
   const { handleCellMouseDown, handleCellMouseEnter, isPreviewCell } =
     useTimeTableDrag({
+      mode,
       selectedWeek,
       availableTimeSlots,
       onSlotsUpdate: (slots) => setAvailableTimeSlots(slots),
@@ -45,11 +47,16 @@ const TimeTable = ({
 
         {/* 시간 셀들 - 빈 7 * 11개의 셀 */}
         <TimeCells
+          mode={mode}
           totalHours={TIME_TABLE_CONFIG.TOTAL_HOURS}
           selectedWeek={selectedWeek}
-          handleCellMouseDown={handleCellMouseDown}
-          handleCellMouseEnter={handleCellMouseEnter}
-          isPreviewCell={isPreviewCell}
+          handleCellMouseDown={
+            mode === "edit" ? handleCellMouseDown : undefined
+          }
+          handleCellMouseEnter={
+            mode === "edit" ? handleCellMouseEnter : undefined
+          }
+          isPreviewCell={mode === "edit" ? isPreviewCell : undefined}
         />
 
         {/* 유휴시간 블록들 - TimeCell 위 블록*/}

--- a/frontend/src/features/timeTable/useTimeTableDrag.ts
+++ b/frontend/src/features/timeTable/useTimeTableDrag.ts
@@ -1,5 +1,8 @@
 import { TIME_TABLE_CONFIG } from "@/features/timeTable/TimeTable.constants";
-import type { AvailableTimeSlotType } from "@/features/timeTable/TimeTable.type";
+import type {
+  AvailableTimeSlotType,
+  TimeTableMode,
+} from "@/features/timeTable/TimeTable.type";
 import { formatHourWithColons } from "@/features/timeTable/TimeTable.util";
 import { format } from "date-fns";
 import { useState, useEffect, useCallback } from "react";
@@ -11,12 +14,14 @@ interface DragState {
 }
 
 interface useTimeTableDragProps {
+  mode: TimeTableMode;
   selectedWeek: Date[];
   availableTimeSlots: AvailableTimeSlotType[];
   onSlotsUpdate?: (slots: AvailableTimeSlotType[]) => void;
 }
 
 export const useTimeTableDrag = ({
+  mode,
   selectedWeek,
   availableTimeSlots,
   onSlotsUpdate,
@@ -28,6 +33,7 @@ export const useTimeTableDrag = ({
   });
 
   const handleCellMouseDown = (dayIndex: number, hourIndex: number) => {
+    if (mode !== "edit") return;
     if (dragState.isDragging) return;
 
     // 해당 위치에 이미 슬롯이 있는지 확인
@@ -50,6 +56,8 @@ export const useTimeTableDrag = ({
   };
 
   const handleCellMouseEnter = (dayIndex: number, hourIndex: number) => {
+    if (mode !== "edit") return;
+
     if (!dragState.isDragging) return;
 
     // 가로 드래그 무시
@@ -98,6 +106,7 @@ export const useTimeTableDrag = ({
 
   const isPreviewCell = useCallback(
     (dayIndex: number, hourIndex: number) => {
+      if (mode !== "edit") return false;
       const { isDragging, startPosition, currentPosition } = dragState;
 
       if (!isDragging || !startPosition || !currentPosition) {
@@ -110,7 +119,7 @@ export const useTimeTableDrag = ({
         hourIndex <= currentPosition.hourIndex
       );
     },
-    [dragState],
+    [dragState, mode],
   );
 
   return {

--- a/frontend/src/pages/admin/centers/CenterDetailPage.tsx
+++ b/frontend/src/pages/admin/centers/CenterDetailPage.tsx
@@ -60,6 +60,7 @@ const CenterDetailPage = () => {
         <h4 css={SectionLabel}>차량 시간표</h4>
         <div css={TableSection}>
           <TimeTable
+            mode="view"
             selectedCarId={selectedCarId}
             selectedWeek={state.selectedWeek}
           />


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Close #194 

## 📝 기능 설명
TimeTable 컴포넌트에 추가 전 필터링 기능을 추가했습니다.

## 🛠 작업 사항
- TimeTable 컴포넌트는 읽기전용 / 수정가능 모드가 분리되어야하기 때문에 props에 `mode: "view"|"edit"` 을 추가했습니다.
- 유휴시간은 2시간 이상일 때만 생성되도록 로직을 추가했습니다.
- 현재 선택된 주 배열과 유휴시간 블록 배열을 비교해서, 다른 주의 배열이면 렌더링되지 않도록 했습니다.

p.s: 유휴시간 추가 / 수정을 위해서 리팩토링이 필요할 것 같아서, PR을 작게 쪼개서 올릴 예정입니다. 아직은 리팩토링 전이라 로직이 바뀔 수 있으니, mode 변경쪽 아이디어 위주로 확인해주세요 !

## ✅ 작업 항목
- [x] TimeTable에 mode 추가
- [x] 유휴시간은 2시간 이상일 때만 생성되도록 로직을 추가
- [x] 다른 주의 데이터는 렌더링되지 않도록 막음

## 📎 참고 자료
이전 - 다른 주 데이터가 나타났다가 사라지며 깜빡임이 심함
https://github.com/user-attachments/assets/489d66ee-92e2-4872-8ba7-ed51d117c07f

이후 - 깜빡임은 아직 존재하지만 다른 주 데이터가 나타나지 않음

https://github.com/user-attachments/assets/06609c6b-2af0-45f1-9853-27808508ec20