### PR TITLE
[Chore/#198] S3 설정 변경 

### DIFF
--- a/backend/src/main/java/hyfive/gachita/car/S3Service.java
+++ b/backend/src/main/java/hyfive/gachita/car/S3Service.java
@@ -25,7 +25,7 @@ public class S3Service {
     private final S3Client s3Client;
 
     private final String BASE_PATH = "images/";
-    private final long MAX_FILE_SIZE = 50 * 1024 * 1024;
+    private final long MAX_FILE_SIZE = 20 * 1024 * 1024;
 
     public String uploadImage(MultipartFile file) {
         try {

--- a/backend/src/main/java/hyfive/gachita/car/S3Service.java
+++ b/backend/src/main/java/hyfive/gachita/car/S3Service.java
@@ -25,7 +25,7 @@ public class S3Service {
     private final S3Client s3Client;
 
     private final String BASE_PATH = "images/";
-    private final long MAX_FILE_SIZE = 10 * 1024 * 1024;
+    private final long MAX_FILE_SIZE = 50 * 1024 * 1024;
 
     public String uploadImage(MultipartFile file) {
         try {

--- a/backend/src/main/java/hyfive/gachita/docs/RentalDocs.java
+++ b/backend/src/main/java/hyfive/gachita/docs/RentalDocs.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.NotNull;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.validation.annotation.Validated;
@@ -17,6 +18,7 @@ import org.springframework.validation.annotation.Validated;
 import java.time.LocalDate;
 import java.util.List;
 
+@Tag(name = "rental", description = "유휴 시간 관련 API")
 public interface RentalDocs {
 
     @Operation(

--- a/backend/src/main/resources/application-init.properties
+++ b/backend/src/main/resources/application-init.properties
@@ -39,8 +39,8 @@ springdoc.api-docs.path=/v3/api-docs
 springdoc.packages-to-scan=hyfive.gachita
 
 # multipart
-spring.servlet.multipart.max-file-size=10MB
-spring.servlet.multipart.max-request-size=10MB
+spring.servlet.multipart.max-file-size=50MB
+spring.servlet.multipart.max-request-size=50MB
 
 # api
 geocode.api.base-url=${GEOCODE_API_BASE_URL}

--- a/backend/src/main/resources/application-init.properties
+++ b/backend/src/main/resources/application-init.properties
@@ -39,8 +39,8 @@ springdoc.api-docs.path=/v3/api-docs
 springdoc.packages-to-scan=hyfive.gachita
 
 # multipart
-spring.servlet.multipart.max-file-size=50MB
-spring.servlet.multipart.max-request-size=50MB
+spring.servlet.multipart.max-file-size=20MB
+spring.servlet.multipart.max-request-size=20MB
 
 # api
 geocode.api.base-url=${GEOCODE_API_BASE_URL}

--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -25,8 +25,8 @@ springdoc.api-docs.path=/v3/api-docs
 springdoc.packages-to-scan=hyfive.gachita
 
 # multipart
-spring.servlet.multipart.max-file-size=10MB
-spring.servlet.multipart.max-request-size=10MB
+spring.servlet.multipart.max-file-size=50MB
+spring.servlet.multipart.max-request-size=50MB
 
 # api
 geocode.api.base-url=${GEOCODE_API_BASE_URL}

--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -25,8 +25,8 @@ springdoc.api-docs.path=/v3/api-docs
 springdoc.packages-to-scan=hyfive.gachita
 
 # multipart
-spring.servlet.multipart.max-file-size=50MB
-spring.servlet.multipart.max-request-size=50MB
+spring.servlet.multipart.max-file-size=20MB
+spring.servlet.multipart.max-request-size=20MB
 
 # api
 geocode.api.base-url=${GEOCODE_API_BASE_URL}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Close #198 

## 📝 기능 설명

FE와 맞추기 위해 S3 이미지 업로드 기능 설정을  변경했습니다.

## 🛠 작업 사항

- 이미지 사이즈 제한 : 50MB
- 허용 이미지 확장자 : jpg, jpeg, png, gif, webp

## ✅ 작업 항목
- [x] 이미지 사이즈 제한 변경 
- [x] rentalDocs tag 추가

## 📎 참고 자료
