### PR TITLE
[Feat/#204] 차량 수정 기능 구현

### DIFF
--- a/frontend/src/components/Button.tsx
+++ b/frontend/src/components/Button.tsx
@@ -11,6 +11,7 @@ interface ButtonProps {
   bgColor?: Color;
   size?: Size;
   type?: "submit" | "button" | "reset";
+  disabled?: boolean;
 }
 
 const Button = ({
@@ -18,6 +19,7 @@ const Button = ({
   bgColor = "orange",
   size = "small",
   type = "button",
+  disabled = false,
 }: ButtonProps) => {
   const [isPressing, setIsPressing] = useState(false);
   const handlers = usePressDetection({
@@ -28,6 +30,7 @@ const Button = ({
       type={type}
       {...handlers}
       css={ButtonContainer(bgColor, size, isPressing)}
+      disabled={disabled}
     >
       {label}
     </button>

--- a/frontend/src/features/carUploader/ImageInput.tsx
+++ b/frontend/src/features/carUploader/ImageInput.tsx
@@ -21,23 +21,25 @@ import {
   TitleText,
 } from "@/features/carUploader/ImageInput.styles";
 import useDocumentEvent from "@/hooks/useDocumentEvent";
-import type { UseFormSetError } from "react-hook-form";
+import type { UseFormClearErrors, UseFormSetError } from "react-hook-form";
 
 interface ImageInputProps {
   value: File | null;
   onChange: (value: File | null) => void;
   errorMessage?: string;
   setError: UseFormSetError<{ carImage: File }>;
+  clearErrors: UseFormClearErrors<{ carImage: File }>;
 }
 const ImageInput = ({
   value,
   onChange,
   setError,
+  clearErrors,
   errorMessage,
 }: ImageInputProps) => {
   useDocumentEvent();
   const { handleUploadImage, handleUploadImageByDrag, handleRemoveImage } =
-    useUploadImage({ onChange, setError });
+    useUploadImage({ onChange, setError, clearErrors });
   const { previewUrl } = usePreviewImage({ value });
   const { dragActive, handleDropImage, handleDragActive } = useDragImage({
     handleUploadImage: handleUploadImageByDrag,

--- a/frontend/src/features/carUploader/ImageInput.tsx
+++ b/frontend/src/features/carUploader/ImageInput.tsx
@@ -21,25 +21,26 @@ import {
   TitleText,
 } from "@/features/carUploader/ImageInput.styles";
 import useDocumentEvent from "@/hooks/useDocumentEvent";
-import type { UseFormClearErrors, UseFormSetError } from "react-hook-form";
+import type { UseFormClearErrors } from "react-hook-form";
+import { useState } from "react";
 
 interface ImageInputProps {
   value: File | string | null;
   onChange: (value: File | null) => void;
   errorMessage?: string;
-  setError: UseFormSetError<{ carImage: File }>;
   clearErrors: UseFormClearErrors<{ carImage: File }>;
 }
 const ImageInput = ({
   value,
   onChange,
-  setError,
   clearErrors,
   errorMessage,
 }: ImageInputProps) => {
+  const [realTimeError, setRealTimeError] = useState<string | null>(null);
+
   useDocumentEvent();
   const { handleUploadImage, handleUploadImageByDrag, handleRemoveImage } =
-    useUploadImage({ onChange, setError, clearErrors });
+    useUploadImage({ onChange, setRealTimeError, clearErrors });
   const { previewUrl } = usePreviewImage({ value });
   const { dragActive, handleDropImage, handleDragActive } = useDragImage({
     handleUploadImage: handleUploadImageByDrag,
@@ -86,7 +87,9 @@ const ImageInput = ({
           </div>
         )}
       </div>
-      {errorMessage && <p css={ErrorText}>{errorMessage}</p>}
+      {(errorMessage || realTimeError) && (
+        <p css={ErrorText}>{realTimeError ? realTimeError : errorMessage}</p>
+      )}
     </div>
   );
 };

--- a/frontend/src/features/carUploader/ImageInput.tsx
+++ b/frontend/src/features/carUploader/ImageInput.tsx
@@ -24,7 +24,7 @@ import useDocumentEvent from "@/hooks/useDocumentEvent";
 import type { UseFormClearErrors, UseFormSetError } from "react-hook-form";
 
 interface ImageInputProps {
-  value: File | null;
+  value: File | string | null;
   onChange: (value: File | null) => void;
   errorMessage?: string;
   setError: UseFormSetError<{ carImage: File }>;

--- a/frontend/src/features/carUploader/ImageInput.tsx
+++ b/frontend/src/features/carUploader/ImageInput.tsx
@@ -71,7 +71,7 @@ const ImageInput = ({
             <div css={TextWrapper}>
               <p css={TitleText}>업로드할 파일을 끌어다 놓으세요.</p>
               <p css={DescriptionText}>
-                JPG, PNG 형식의 파일을 업로드할 수 있습니다.
+                JPG, PNG, GIF, WEBP 형식의 파일을 업로드할 수 있습니다.
               </p>
             </div>
             <label htmlFor="carImage" css={Linktext}>

--- a/frontend/src/features/carUploader/ImageValidator.util.ts
+++ b/frontend/src/features/carUploader/ImageValidator.util.ts
@@ -1,4 +1,4 @@
-const MAX_FILE_SIZE = 1024 * 1024 * 50; //50MB
+const MAX_FILE_SIZE = 1024 * 1024 * 20; //20MB
 const ACCEPTED_IMAGE_MIME_TYPES = [
   "image/jpeg",
   "image/jpg",

--- a/frontend/src/features/carUploader/ImageValidator.util.ts
+++ b/frontend/src/features/carUploader/ImageValidator.util.ts
@@ -1,5 +1,11 @@
-const MAX_FILE_SIZE = 1024 * 1024 * 1024 * 500;
-const ACCEPTED_IMAGE_MIME_TYPES = ["image/jpeg", "image/jpg", "image/png"];
+const MAX_FILE_SIZE = 1024 * 1024 * 50; //50MB
+const ACCEPTED_IMAGE_MIME_TYPES = [
+  "image/jpeg",
+  "image/jpg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+];
 
 const ImageValidator = (file: File) => {
   const validateImageSize = () => {

--- a/frontend/src/features/carUploader/InputSection.tsx
+++ b/frontend/src/features/carUploader/InputSection.tsx
@@ -12,12 +12,9 @@ import useCarForm, {
 type InputMode = "register" | "edit";
 interface InputSectionProps {
   type?: InputMode;
-  defaultValues?: Partial<CarFormValues>;
+  initValues?: CarFormValues;
 }
-const InputSection = ({
-  type = "register",
-  defaultValues,
-}: InputSectionProps) => {
+const InputSection = ({ type = "register", initValues }: InputSectionProps) => {
   const MAX_PASSENGER = 25;
   const dropdownOptions = Array.from({ length: MAX_PASSENGER }, (_, index) =>
     String(index + 1),
@@ -27,17 +24,17 @@ const InputSection = ({
     register,
     control,
     handleSubmit,
+    handleReset,
     setError,
-    reset,
     formState: { errors, isValid },
-  } = useCarForm(defaultValues);
+  } = useCarForm(initValues);
 
   return (
     <form
       css={InputSectionContainer}
       onSubmit={handleSubmit((e) => {
         console.log(e);
-        reset();
+        handleReset();
       })}
     >
       <Controller

--- a/frontend/src/features/carUploader/InputSection.tsx
+++ b/frontend/src/features/carUploader/InputSection.tsx
@@ -8,6 +8,7 @@ import { Controller } from "react-hook-form";
 import useCarForm, {
   type CarFormValues,
 } from "@/features/carUploader/useCarForm";
+import { useMemo } from "react";
 
 type InputMode = "register" | "edit";
 interface InputSectionProps {
@@ -23,11 +24,22 @@ const InputSection = ({ type = "register", initValues }: InputSectionProps) => {
   const {
     register,
     control,
+    watch,
     handleSubmit,
     handleReset,
     clearErrors,
     formState: { errors, isValid },
   } = useCarForm(initValues);
+
+  const watchValues = watch();
+  const isChanged = useMemo(() => {
+    if (!initValues) return true;
+    return Object.keys(initValues).some(
+      (key) =>
+        watchValues[key as keyof CarFormValues] !==
+        initValues[key as keyof CarFormValues],
+    );
+  }, [watchValues, initValues]);
 
   return (
     <form
@@ -97,9 +109,10 @@ const InputSection = ({ type = "register", initValues }: InputSectionProps) => {
       />
       <Button
         type="submit"
-        bgColor={isValid ? "orange" : "gray"}
+        bgColor={isChanged && isValid ? "orange" : "gray"}
         label={type === "register" ? "등록하기" : "수정하기"}
         size="big"
+        disabled={!isChanged}
       />
     </form>
   );

--- a/frontend/src/features/carUploader/InputSection.tsx
+++ b/frontend/src/features/carUploader/InputSection.tsx
@@ -5,9 +5,19 @@ import ImageInput from "@/features/carUploader/ImageInput";
 import { css } from "@emotion/react";
 import Button from "@/components/Button";
 import { Controller } from "react-hook-form";
-import useCarForm from "@/features/carUploader/useCarForm";
+import useCarForm, {
+  type CarFormValues,
+} from "@/features/carUploader/useCarForm";
 
-const InputSection = () => {
+type InputMode = "register" | "edit";
+interface InputSectionProps {
+  type?: InputMode;
+  defaultValues?: Partial<CarFormValues>;
+}
+const InputSection = ({
+  type = "register",
+  defaultValues,
+}: InputSectionProps) => {
   const MAX_PASSENGER = 25;
   const dropdownOptions = Array.from({ length: MAX_PASSENGER }, (_, index) =>
     String(index + 1),
@@ -20,7 +30,7 @@ const InputSection = () => {
     setError,
     reset,
     formState: { errors, isValid },
-  } = useCarForm();
+  } = useCarForm(defaultValues);
 
   return (
     <form
@@ -91,7 +101,7 @@ const InputSection = () => {
       <Button
         type="submit"
         bgColor={isValid ? "orange" : "gray"}
-        label="등록하기"
+        label={type === "register" ? "등록하기" : "수정하기"}
         size="big"
       />
     </form>

--- a/frontend/src/features/carUploader/InputSection.tsx
+++ b/frontend/src/features/carUploader/InputSection.tsx
@@ -26,6 +26,7 @@ const InputSection = ({ type = "register", initValues }: InputSectionProps) => {
     handleSubmit,
     handleReset,
     setError,
+    clearErrors,
     formState: { errors, isValid },
   } = useCarForm(initValues);
 
@@ -45,6 +46,7 @@ const InputSection = ({ type = "register", initValues }: InputSectionProps) => {
             value={field.value}
             onChange={(value) => field.onChange(value)}
             setError={setError}
+            clearErrors={clearErrors}
             errorMessage={errors.carImage?.message?.toString()}
           />
         )}

--- a/frontend/src/features/carUploader/InputSection.tsx
+++ b/frontend/src/features/carUploader/InputSection.tsx
@@ -25,7 +25,6 @@ const InputSection = ({ type = "register", initValues }: InputSectionProps) => {
     control,
     handleSubmit,
     handleReset,
-    setError,
     clearErrors,
     formState: { errors, isValid },
   } = useCarForm(initValues);
@@ -45,7 +44,6 @@ const InputSection = ({ type = "register", initValues }: InputSectionProps) => {
           <ImageInput
             value={field.value}
             onChange={(value) => field.onChange(value)}
-            setError={setError}
             clearErrors={clearErrors}
             errorMessage={errors.carImage?.message?.toString()}
           />

--- a/frontend/src/features/carUploader/InputSection.tsx
+++ b/frontend/src/features/carUploader/InputSection.tsx
@@ -44,8 +44,7 @@ const InputSection = ({ type = "register", initValues }: InputSectionProps) => {
   return (
     <form
       css={InputSectionContainer}
-      onSubmit={handleSubmit((e) => {
-        console.log(e);
+      onSubmit={handleSubmit(() => {
         handleReset();
       })}
     >

--- a/frontend/src/features/carUploader/InputSection.tsx
+++ b/frontend/src/features/carUploader/InputSection.tsx
@@ -45,7 +45,7 @@ const InputSection = ({ type = "register", initValues }: InputSectionProps) => {
             value={field.value}
             onChange={(value) => field.onChange(value)}
             setError={setError}
-            errorMessage={errors.carImage?.message}
+            errorMessage={errors.carImage?.message?.toString()}
           />
         )}
       />

--- a/frontend/src/features/carUploader/InputSection.tsx
+++ b/frontend/src/features/carUploader/InputSection.tsx
@@ -33,7 +33,7 @@ const InputSection = ({ type = "register", initValues }: InputSectionProps) => {
 
   const watchValues = watch();
   const isChanged = useMemo(() => {
-    if (!initValues) return true;
+    if (!initValues) return false;
     return Object.keys(initValues).some(
       (key) =>
         watchValues[key as keyof CarFormValues] !==

--- a/frontend/src/features/carUploader/useCarForm.ts
+++ b/frontend/src/features/carUploader/useCarForm.ts
@@ -2,6 +2,14 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
+export type CarFormValues = {
+  carImage: File;
+  carModel: string;
+  carNumber: string;
+  maxPassenger: string;
+  isLowFloor: boolean;
+};
+
 const carSchema = z.object({
   carImage: z.instanceof(File, { message: "필수 입력값입니다" }),
   carModel: z.string().min(1, "필수 입력값입니다"),
@@ -14,9 +22,9 @@ const carSchema = z.object({
   isLowFloor: z.boolean(),
 });
 
-const useCarForm = () => {
+const useCarForm = (defaultValues?: Partial<CarFormValues>) => {
   const { register, control, handleSubmit, setError, reset, formState } =
-    useForm({
+    useForm<CarFormValues>({
       mode: "onSubmit",
       resolver: zodResolver(carSchema),
       defaultValues: {
@@ -25,6 +33,7 @@ const useCarForm = () => {
         carNumber: "",
         maxPassenger: "",
         isLowFloor: false,
+        ...defaultValues,
       },
     });
 

--- a/frontend/src/features/carUploader/useCarForm.ts
+++ b/frontend/src/features/carUploader/useCarForm.ts
@@ -3,7 +3,7 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 
 export type CarFormValues = {
-  carImage: File | null;
+  carImage: File | string;
   carModel: string;
   carNumber: string;
   maxPassenger: string;
@@ -19,7 +19,7 @@ const emptyValues = {
 };
 
 const carSchema = z.object({
-  carImage: z.any().refine((value) => value instanceof File, {
+  carImage: z.any().refine((value) => value !== null && value !== undefined, {
     message: "필수 입력값입니다",
   }),
   carModel: z.string().min(1, "필수 입력값입니다"),

--- a/frontend/src/features/carUploader/useCarForm.ts
+++ b/frontend/src/features/carUploader/useCarForm.ts
@@ -10,7 +10,7 @@ export type CarFormValues = {
   isLowFloor: boolean;
 };
 
-const EMPTY_VALUES = {
+const emptyValues = {
   carImage: null,
   carModel: "",
   carNumber: "",
@@ -38,13 +38,13 @@ const useCarForm = (initValues?: CarFormValues) => {
       mode: "onSubmit",
       resolver: zodResolver(carSchema),
       defaultValues: {
-        ...EMPTY_VALUES,
+        ...emptyValues,
         ...initValues,
       },
     });
 
   const handleReset = () => {
-    reset(EMPTY_VALUES);
+    reset(emptyValues);
   };
 
   return {

--- a/frontend/src/features/carUploader/useCarForm.ts
+++ b/frontend/src/features/carUploader/useCarForm.ts
@@ -33,22 +33,15 @@ const carSchema = z.object({
 });
 
 const useCarForm = (initValues?: CarFormValues) => {
-  const {
-    register,
-    control,
-    handleSubmit,
-    setError,
-    clearErrors,
-    reset,
-    formState,
-  } = useForm({
-    mode: "onSubmit",
-    resolver: zodResolver(carSchema),
-    defaultValues: {
-      ...emptyValues,
-      ...initValues,
-    },
-  });
+  const { register, control, handleSubmit, clearErrors, reset, formState } =
+    useForm({
+      mode: "onSubmit",
+      resolver: zodResolver(carSchema),
+      defaultValues: {
+        ...emptyValues,
+        ...initValues,
+      },
+    });
 
   const handleReset = () => {
     reset(emptyValues);
@@ -59,7 +52,6 @@ const useCarForm = (initValues?: CarFormValues) => {
     control,
     handleSubmit,
     handleReset,
-    setError,
     clearErrors,
     formState,
   };

--- a/frontend/src/features/carUploader/useCarForm.ts
+++ b/frontend/src/features/carUploader/useCarForm.ts
@@ -3,15 +3,25 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 
 export type CarFormValues = {
-  carImage: File;
+  carImage: File | null;
   carModel: string;
   carNumber: string;
   maxPassenger: string;
   isLowFloor: boolean;
 };
 
+const EMPTY_VALUES = {
+  carImage: null,
+  carModel: "",
+  carNumber: "",
+  maxPassenger: "",
+  isLowFloor: false,
+};
+
 const carSchema = z.object({
-  carImage: z.instanceof(File, { message: "필수 입력값입니다" }),
+  carImage: z.any().refine((value) => value instanceof File, {
+    message: "필수 입력값입니다",
+  }),
   carModel: z.string().min(1, "필수 입력값입니다"),
   carNumber: z.string().refine((value) => /^\d{2,3}[가-힣]\d{4}$/.test(value), {
     message: "올바른 차량 번호 형식이 아닙니다 (예: 12가3456)",
@@ -22,27 +32,27 @@ const carSchema = z.object({
   isLowFloor: z.boolean(),
 });
 
-const useCarForm = (defaultValues?: Partial<CarFormValues>) => {
+const useCarForm = (initValues?: CarFormValues) => {
   const { register, control, handleSubmit, setError, reset, formState } =
-    useForm<CarFormValues>({
+    useForm({
       mode: "onSubmit",
       resolver: zodResolver(carSchema),
       defaultValues: {
-        carImage: undefined,
-        carModel: "",
-        carNumber: "",
-        maxPassenger: "",
-        isLowFloor: false,
-        ...defaultValues,
+        ...EMPTY_VALUES,
+        ...initValues,
       },
     });
+
+  const handleReset = () => {
+    reset(EMPTY_VALUES);
+  };
 
   return {
     register,
     control,
     handleSubmit,
+    handleReset,
     setError,
-    reset,
     formState,
   };
 };

--- a/frontend/src/features/carUploader/useCarForm.ts
+++ b/frontend/src/features/carUploader/useCarForm.ts
@@ -3,7 +3,7 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 
 export type CarFormValues = {
-  carImage: File | string;
+  carImage: File | string | null;
   carModel: string;
   carNumber: string;
   maxPassenger: string;
@@ -33,15 +33,22 @@ const carSchema = z.object({
 });
 
 const useCarForm = (initValues?: CarFormValues) => {
-  const { register, control, handleSubmit, clearErrors, reset, formState } =
-    useForm({
-      mode: "onSubmit",
-      resolver: zodResolver(carSchema),
-      defaultValues: {
-        ...emptyValues,
-        ...initValues,
-      },
-    });
+  const {
+    register,
+    control,
+    watch,
+    handleSubmit,
+    clearErrors,
+    reset,
+    formState,
+  } = useForm<CarFormValues>({
+    mode: "onSubmit",
+    resolver: zodResolver(carSchema),
+    defaultValues: {
+      ...emptyValues,
+      ...initValues,
+    },
+  });
 
   const handleReset = () => {
     reset(emptyValues);
@@ -50,6 +57,7 @@ const useCarForm = (initValues?: CarFormValues) => {
   return {
     register,
     control,
+    watch,
     handleSubmit,
     handleReset,
     clearErrors,

--- a/frontend/src/features/carUploader/useCarForm.ts
+++ b/frontend/src/features/carUploader/useCarForm.ts
@@ -33,15 +33,22 @@ const carSchema = z.object({
 });
 
 const useCarForm = (initValues?: CarFormValues) => {
-  const { register, control, handleSubmit, setError, reset, formState } =
-    useForm({
-      mode: "onSubmit",
-      resolver: zodResolver(carSchema),
-      defaultValues: {
-        ...emptyValues,
-        ...initValues,
-      },
-    });
+  const {
+    register,
+    control,
+    handleSubmit,
+    setError,
+    clearErrors,
+    reset,
+    formState,
+  } = useForm({
+    mode: "onSubmit",
+    resolver: zodResolver(carSchema),
+    defaultValues: {
+      ...emptyValues,
+      ...initValues,
+    },
+  });
 
   const handleReset = () => {
     reset(emptyValues);
@@ -53,6 +60,7 @@ const useCarForm = (initValues?: CarFormValues) => {
     handleSubmit,
     handleReset,
     setError,
+    clearErrors,
     formState,
   };
 };

--- a/frontend/src/features/carUploader/usePreviewImage.ts
+++ b/frontend/src/features/carUploader/usePreviewImage.ts
@@ -1,13 +1,20 @@
 import { useEffect, useState } from "react";
 
 interface UsePreviewImageProps {
-  value: File | null;
+  value: File | string | null;
 }
 
 const usePreviewImage = ({ value }: UsePreviewImageProps) => {
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
 
   useEffect(() => {
+    //url인 이미 업로드된 이미지인 경우 처리
+    if (typeof value === "string") {
+      setPreviewUrl(value);
+      return;
+    }
+
+    //url이 아닌 직접 업로드한 이미지인 경우 처리
     if (value) {
       const url = URL.createObjectURL(value);
       setPreviewUrl(url);

--- a/frontend/src/features/carUploader/useUploadImage.ts
+++ b/frontend/src/features/carUploader/useUploadImage.ts
@@ -18,7 +18,7 @@ const useUploadImage = ({
 
     if (!validateImageType()) {
       onChange(null);
-      setError("carImage", { message: "JPG/PNG만 업로드 가능합니다" });
+      setError("carImage", { message: "이미지만 업로드 가능합니다" });
       return;
     }
     if (!validateImageSize()) {

--- a/frontend/src/features/carUploader/useUploadImage.ts
+++ b/frontend/src/features/carUploader/useUploadImage.ts
@@ -1,13 +1,18 @@
 import ImageValidator from "@/features/carUploader/ImageValidator.util";
 import type { ChangeEvent } from "react";
-import type { UseFormSetError } from "react-hook-form";
+import type { UseFormClearErrors, UseFormSetError } from "react-hook-form";
 
 interface UseUploadImageProps {
   onChange: (value: File | null) => void;
   setError: UseFormSetError<{ carImage: File }>;
+  clearErrors: UseFormClearErrors<{ carImage: File }>;
 }
 
-const useUploadImage = ({ onChange, setError }: UseUploadImageProps) => {
+const useUploadImage = ({
+  onChange,
+  setError,
+  clearErrors,
+}: UseUploadImageProps) => {
   const handleUploadImageTemplate = (file: File) => {
     const { validateImageType, validateImageSize } = ImageValidator(file);
 
@@ -21,7 +26,7 @@ const useUploadImage = ({ onChange, setError }: UseUploadImageProps) => {
       setError("carImage", { message: "최대 크기는 50MB입니다" });
       return;
     }
-
+    clearErrors("carImage");
     onChange(file);
   };
 

--- a/frontend/src/features/carUploader/useUploadImage.ts
+++ b/frontend/src/features/carUploader/useUploadImage.ts
@@ -23,7 +23,7 @@ const useUploadImage = ({
     }
     if (!validateImageSize()) {
       onChange(null);
-      setRealTimeError("최대 크기는 50MB입니다");
+      setRealTimeError("최대 크기는 20MB입니다");
       return;
     }
     clearErrors("carImage");

--- a/frontend/src/features/carUploader/useUploadImage.ts
+++ b/frontend/src/features/carUploader/useUploadImage.ts
@@ -1,16 +1,16 @@
 import ImageValidator from "@/features/carUploader/ImageValidator.util";
-import type { ChangeEvent } from "react";
-import type { UseFormClearErrors, UseFormSetError } from "react-hook-form";
+import type { ChangeEvent, Dispatch, SetStateAction } from "react";
+import type { UseFormClearErrors } from "react-hook-form";
 
 interface UseUploadImageProps {
   onChange: (value: File | null) => void;
-  setError: UseFormSetError<{ carImage: File }>;
+  setRealTimeError: Dispatch<SetStateAction<string | null>>;
   clearErrors: UseFormClearErrors<{ carImage: File }>;
 }
 
 const useUploadImage = ({
   onChange,
-  setError,
+  setRealTimeError,
   clearErrors,
 }: UseUploadImageProps) => {
   const handleUploadImageTemplate = (file: File) => {
@@ -18,15 +18,16 @@ const useUploadImage = ({
 
     if (!validateImageType()) {
       onChange(null);
-      setError("carImage", { message: "이미지만 업로드 가능합니다" });
+      setRealTimeError("이미지만 업로드 가능합니다");
       return;
     }
     if (!validateImageSize()) {
       onChange(null);
-      setError("carImage", { message: "최대 크기는 50MB입니다" });
+      setRealTimeError("최대 크기는 50MB입니다");
       return;
     }
     clearErrors("carImage");
+    setRealTimeError(null);
     onChange(file);
   };
 

--- a/frontend/src/pages/center/CenterEditPage.tsx
+++ b/frontend/src/pages/center/CenterEditPage.tsx
@@ -7,11 +7,21 @@ const { typography } = theme;
 
 const CenterEditPage = () => {
   const location = useLocation();
-  console.log(location.state.file);
+  const { carImage, carModel, carNumber, maxPassenger, isLowFloor } =
+    location.state;
   return (
     <div css={CenterEditPageContainer}>
       <p css={HeaderText}>차량 수정하기</p>
-      <InputSection type="edit" />
+      <InputSection
+        type="edit"
+        defaultValues={{
+          carImage,
+          carModel,
+          carNumber,
+          maxPassenger,
+          isLowFloor,
+        }}
+      />
     </div>
   );
 };

--- a/frontend/src/pages/center/CenterEditPage.tsx
+++ b/frontend/src/pages/center/CenterEditPage.tsx
@@ -1,0 +1,32 @@
+import { css } from "@emotion/react";
+import { theme } from "@/styles/themes.style";
+import InputSection from "@/features/carUploader/InputSection";
+import { useLocation } from "react-router";
+
+const { typography } = theme;
+
+const CenterEditPage = () => {
+  const location = useLocation();
+  console.log(location.state.file);
+  return (
+    <div css={CenterEditPageContainer}>
+      <p css={HeaderText}>차량 수정하기</p>
+      <InputSection type="edit" />
+    </div>
+  );
+};
+
+export default CenterEditPage;
+
+const CenterEditPageContainer = css`
+  display: flex;
+  flex-direction: column;
+  gap: 44px;
+  max-width: 660px;
+  margin: 0 auto;
+  padding: 40px 0;
+`;
+
+const HeaderText = css`
+  font: ${typography.Heading.h3_semi};
+`;

--- a/frontend/src/pages/center/CenterEditPage.tsx
+++ b/frontend/src/pages/center/CenterEditPage.tsx
@@ -7,21 +7,10 @@ const { typography } = theme;
 
 const CenterEditPage = () => {
   const location = useLocation();
-  const { carImage, carModel, carNumber, maxPassenger, isLowFloor } =
-    location.state;
   return (
     <div css={CenterEditPageContainer}>
       <p css={HeaderText}>차량 수정하기</p>
-      <InputSection
-        type="edit"
-        defaultValues={{
-          carImage,
-          carModel,
-          carNumber,
-          maxPassenger,
-          isLowFloor,
-        }}
-      />
+      <InputSection type="edit" initValues={location.state} />
     </div>
   );
 };

--- a/frontend/src/pages/center/CenterPage.tsx
+++ b/frontend/src/pages/center/CenterPage.tsx
@@ -1,26 +1,13 @@
 import { useNavigate } from "react-router";
 import OriginalCarImg from "@/assets/images/OriginalCarImg.png";
-import { useEffect, useState } from "react";
 
 const CenterPage = () => {
   const navigate = useNavigate();
-  const [file, setFile] = useState<File | null>(null);
-
-  useEffect(() => {
-    fetch(OriginalCarImg)
-      .then((res) => res.blob())
-      .then((blob) => {
-        const originFile = new File([blob], "OriginalCarImg.png", {
-          type: blob.type,
-        });
-        setFile(originFile);
-      });
-  }, []);
 
   const handleNavigate = () => {
     navigate("/center/edit", {
       state: {
-        carImage: file,
+        carImage: OriginalCarImg,
         carModel: "람보르기니",
         carNumber: "12가1234",
         maxPassenger: "8",

--- a/frontend/src/pages/center/CenterPage.tsx
+++ b/frontend/src/pages/center/CenterPage.tsx
@@ -1,5 +1,26 @@
+import { useNavigate } from "react-router";
+import OriginalCarImg from "@/assets/images/OriginalCarImg.png";
+
 const CenterPage = () => {
-  return <>Center</>;
+  const navigate = useNavigate();
+
+  const handleNavigate = () => {
+    navigate("/center/edit", {
+      state: {
+        carImage: OriginalCarImg, // 이미지 경로를 state에 전달
+        carModel: "람보르기니",
+        carNumber: "12가1234",
+        maxPassenger: "8",
+        isLowFloor: true,
+      },
+    });
+  };
+
+  return (
+    <>
+      <button onClick={handleNavigate}>navigate to edit</button>
+    </>
+  );
 };
 
 export default CenterPage;

--- a/frontend/src/pages/center/CenterPage.tsx
+++ b/frontend/src/pages/center/CenterPage.tsx
@@ -1,5 +1,4 @@
 import { useNavigate } from "react-router";
-import OriginalCarImg from "@/assets/images/OriginalCarImg.png";
 
 const CenterPage = () => {
   const navigate = useNavigate();
@@ -7,7 +6,6 @@ const CenterPage = () => {
   const handleNavigate = () => {
     navigate("/center/edit", {
       state: {
-        carImage: OriginalCarImg, // 이미지 경로를 state에 전달
         carModel: "람보르기니",
         carNumber: "12가1234",
         maxPassenger: "8",

--- a/frontend/src/pages/center/CenterPage.tsx
+++ b/frontend/src/pages/center/CenterPage.tsx
@@ -1,11 +1,26 @@
 import { useNavigate } from "react-router";
+import OriginalCarImg from "@/assets/images/OriginalCarImg.png";
+import { useEffect, useState } from "react";
 
 const CenterPage = () => {
   const navigate = useNavigate();
+  const [file, setFile] = useState<File | null>(null);
+
+  useEffect(() => {
+    fetch(OriginalCarImg)
+      .then((res) => res.blob())
+      .then((blob) => {
+        const originFile = new File([blob], "OriginalCarImg.png", {
+          type: blob.type,
+        });
+        setFile(originFile);
+      });
+  }, []);
 
   const handleNavigate = () => {
     navigate("/center/edit", {
       state: {
+        carImage: file,
         carModel: "람보르기니",
         carNumber: "12가1234",
         maxPassenger: "8",

--- a/frontend/src/pages/index.ts
+++ b/frontend/src/pages/index.ts
@@ -14,6 +14,7 @@ export { default as CenterDetailPage } from "@/pages/admin/centers/CenterDetailP
 // Center
 export { default as CenterPage } from "@/pages/center/CenterPage";
 export { default as CenterRegisterPage } from "@/pages/center/CenterRegisterPage";
+export { default as CenterEditPage } from "@/pages/center/CenterEditPage";
 
 // NotFound
 export { default as NotFoundPage } from "@/pages/NotFoundPage";

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -13,6 +13,7 @@ import {
   CenterRegisterPage,
   NotFoundPage,
   TestPage,
+  CenterEditPage,
 } from "@/pages";
 import { BrowserRouter, Route, Routes } from "react-router";
 
@@ -40,6 +41,7 @@ const Router = () => {
         <Route path="/center/*" element={<CenterLayout />}>
           <Route index element={<CenterPage />} />
           <Route path="register" element={<CenterRegisterPage />} />
+          <Route path="edit" element={<CenterEditPage />} />
         </Route>
 
         {/* 초기 진입 시 리디렉션 */}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Close #204 

## 📝 기능 설명
차량 수정 기능을 구현했습니다.

## 🛠 작업 사항
### center 페이지에서 File 전달
useNavigate의 navigation state로 File 전달이 가능합니다! 👍🏻 
CenterPage에서 File, string 값을 모두 테스트 완료했습니다. 해당 형태로 주시면 될 것 같아요!

```tsx
const navigate = useNavigate();
const handleNavigate = () => {
  navigate("/center/edit", {
    state: {
      carImage: OriginalCarImg,
      carModel: "람보르기니",
      carNumber: "12가1234",
      maxPassenger: "8",
      isLowFloor: true,
    },
  });
};
```
### zod의 resolver가 setError를 덮어씌우는 현상 해결
#### 문제 상황
onSubmit 후 setError에 대한 에러 메시지가 표시되지 않고 zod의 resolver에 설정한 에러 메시지만 뜨는 예외 상황이 발생했습니다. 이는 resolver가 setError보다 더 상위에 위치해 에러 메시지를 덮어씌우는 작업이 진행되었기 때문입니다.
#### 해결 방법
실시간 검증과 제출했을 때의 검증을 명확히 분리해야 하는 특수한 경우의 이미지 입력 폼이기에, zod로 모든 검증 로직을 합칠 수 없었습니다. 동시에 zod의 resolver가 실시간 검증의 setError를 감추는 문제도 해결할 수 없었습니다.

그렇기에 setError 대신 커스텀 에러 상태를 생성했습니다. setError 자체를 삭제해 실시간 검증에서 발생하는 에러는 더이상 hook-form+zod가 관리하는 값에 포함되지 않습니다.

### 비교 로직 도입: 초기값과 동일한 경우 제출 비활성화
수정시에 초기값과 동일한 경우 제출하는 것이 비효율적이라고 생각해, 비교 로직을 도입했습니다. 비교해서 변경이 발생하지 않았다면, 제출을 비활성화하게 됩니다.

## ✅ 작업 항목

- [x] prop으로 차량 정보 수신
- [x] prop과 hook-form 연동
- [x] 차량 정보 업데이트 기능 구현
- [x] 차량 정보 업데이트시 초기값과 동일한 경우 제출 비활성화

### 추가 발견 이슈
- [x] 유효하지 않은 이미지 경고 발생 후 유효한 이미지 업로드했을 때 경고 초기화되지 않음
- [x] 초기화시 페이지 전환할 때 전달한 값으로 세팅됨(null이 아니라 수정 전 값에 해당)
- [x] 미리보기 이미지 string인 경우 URL 생성할 때 에러 터짐
- [x] onSubmit 후 setError에 대한 에러 메시지가 표시되지 않고 zod에서 설정한 에러 메시지만 뜸

## 📎 참고 자료
### 정적 페이지
<img width="1840" height="1191" alt="image" src="https://github.com/user-attachments/assets/89011027-0cbd-4d64-b532-b58d06910976" />

### 동적 페이지: 비교 로직 도입

https://github.com/user-attachments/assets/208ccfef-dbc2-42e8-b41f-9a7a85090cbd

### 동적 페이지: zod의 resolver가 setError를 덮어씌우는 현상 해결
https://github.com/user-attachments/assets/2fb4de02-f4da-4510-a5fa-2220dd21f094


