### PR TITLE
[Feat/#265] 실시간 예약 현황에 경로 정보 추가

### DIFF
--- a/backend/src/main/java/hyfive/gachita/application/book/BookController.java
+++ b/backend/src/main/java/hyfive/gachita/application/book/BookController.java
@@ -2,6 +2,7 @@ package hyfive.gachita.application.book;
 
 import hyfive.gachita.application.book.dto.BookCursor;
 import hyfive.gachita.application.book.dto.BookRes;
+import hyfive.gachita.application.book.dto.BookWithPathRes;
 import hyfive.gachita.application.book.dto.CreateBookReq;
 import hyfive.gachita.application.common.dto.PagedListRes;
 import hyfive.gachita.application.common.dto.ScrollRes;
@@ -36,7 +37,7 @@ public class BookController implements BookDocs {
     }
 
     @GetMapping("/scroll")
-    public BaseResponse<ScrollRes<BookRes, BookCursor>> getBookListScroll(
+    public BaseResponse<ScrollRes<BookWithPathRes, BookCursor>> getBookListScroll(
             @RequestParam(name = "status", defaultValue = "NEW") BookStatus bookStatus,
             @ModelAttribute BookCursor cursor,
             @RequestParam(name = "size", defaultValue = "10") int size

--- a/backend/src/main/java/hyfive/gachita/application/book/BookService.java
+++ b/backend/src/main/java/hyfive/gachita/application/book/BookService.java
@@ -122,7 +122,7 @@ public class BookService {
     }
 
     @Transactional
-    public void updatePath(Long id, Path path) {
+    public void setPath(Long id, Path path) {
         Book book = bookRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NO_EXIST_VALUE, "DB에 예약 데이터가 존재하지 않습니다."));
         book.setPath(path);

--- a/backend/src/main/java/hyfive/gachita/application/book/BookService.java
+++ b/backend/src/main/java/hyfive/gachita/application/book/BookService.java
@@ -1,5 +1,6 @@
 package hyfive.gachita.application.book;
 
+import hyfive.gachita.application.book.dto.BookWithPathRes;
 import hyfive.gachita.client.geocode.GeoCodeService;
 import hyfive.gachita.client.geocode.dto.LatLng;
 import hyfive.gachita.application.book.dto.BookCursor;
@@ -83,17 +84,17 @@ public class BookService {
                 .build();
     }
 
-    public ScrollRes<BookRes, BookCursor> getBookListScroll(BookStatus bookStatus, BookCursor cursor, int size) {
-        List<Book> bookList = bookRepository.findBooksForScroll(bookStatus, cursor, size);
+    public ScrollRes<BookWithPathRes, BookCursor> getBookListScroll(BookStatus bookStatus, BookCursor cursor, int size) {
+        List<Book> bookList = bookRepository.findBooksForScrollWithPath(bookStatus, cursor, size);
 
         boolean hasNext = bookList.size() > size;
 
         List<Book> actualList = hasNext ? bookList.subList(0, size) : bookList;
 
-        List<BookRes> bookResList = actualList.stream()
-                .map(BookRes::from)
+        List<BookWithPathRes> bookWithPathResList = actualList.stream()
+                .map(BookWithPathRes::from)
                 .toList();
-
+        
         BookCursor lastCursor = null;
         if (!actualList.isEmpty()) {
             Book lastBook = actualList.get(actualList.size() - 1);
@@ -103,8 +104,8 @@ public class BookService {
                     .build();
         }
 
-        return ScrollRes.<BookRes, BookCursor>builder()
-                .items(bookResList)
+        return ScrollRes.<BookWithPathRes, BookCursor>builder()
+                .items(bookWithPathResList)
                 .hasNext(hasNext)
                 .cursor(lastCursor)
                 .build();

--- a/backend/src/main/java/hyfive/gachita/application/book/BookService.java
+++ b/backend/src/main/java/hyfive/gachita/application/book/BookService.java
@@ -85,7 +85,8 @@ public class BookService {
     }
 
     public ScrollRes<BookWithPathRes, BookCursor> getBookListScroll(BookStatus bookStatus, BookCursor cursor, int size) {
-        List<Book> bookList = bookRepository.findBooksForScrollWithPath(bookStatus, cursor, size);
+        Pair<LocalDateTime, LocalDateTime> dateRange = DateRangeUtil.getDateRange(LocalDateTime.now(), SearchPeriod.TODAY);
+        List<Book> bookList = bookRepository.findBooksForScrollWithPath(dateRange, bookStatus, cursor, size);
 
         boolean hasNext = bookList.size() > size;
 

--- a/backend/src/main/java/hyfive/gachita/application/book/dto/BookWithPathRes.java
+++ b/backend/src/main/java/hyfive/gachita/application/book/dto/BookWithPathRes.java
@@ -1,0 +1,72 @@
+package hyfive.gachita.application.book.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import hyfive.gachita.application.book.Book;
+import hyfive.gachita.application.book.BookStatus;
+import hyfive.gachita.application.path.dto.PathRes;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record BookWithPathRes(
+        @Schema(description = "예약 ID", example = "1")
+        Long id,
+
+        @Schema(description = "예약자 이름", example = "홍길동")
+        String bookName,
+
+        @Schema(description = "예약자 전화번호", example = "010-1234-5678")
+        String bookTel,
+
+        @Schema(description = "예약 생성 날짜 (yyyy.MM.dd)", example = "2025.08.06")
+        @JsonFormat(pattern = "yyyy.MM.dd")
+        LocalDate bookDate,
+
+        @Schema(description = "예약 생성 시간 (HH:mm)", example = "09:15")
+        @JsonFormat(pattern = "HH:mm")
+        @JsonProperty("bookTime")
+        LocalTime bookTime,
+
+        @Schema(description = "병원 예약 날짜 (yyyy.MM.dd)", example = "2025.08.10")
+        @JsonFormat(pattern = "yyyy.MM.dd")
+        LocalDate hospitalDate,
+
+        @Schema(description = "병원 예약 시간 (HH:mm)", example = "10:30")
+        @JsonFormat(pattern = "HH:mm")
+        @JsonProperty("hospitalTime")
+        LocalTime hospitalTime,
+
+        @Schema(description = "출발지 주소", example = "서울특별시 노원구 동일로 123")
+        String startAddr,
+
+        @Schema(description = "도착지 주소", example = "서울특별시 노원구 노해로 45")
+        String endAddr,
+
+        @Schema(description = "보행기 사용 여부", example = "true")
+        Boolean walker,
+
+        @Schema(description = "예약 상태", example = "NEW")
+        BookStatus bookStatus,
+
+        @Schema(description = "예약에 따른 경로 정보")
+        PathRes path
+) {
+        public static BookWithPathRes from(Book book) {
+                return new BookWithPathRes(
+                        book.getId(),
+                        book.getBookName(),
+                        book.getBookTel(),
+                        book.getCreatedAt().toLocalDate(),
+                        book.getCreatedAt().toLocalTime(),
+                        book.getHospitalDate(),
+                        book.getHospitalTime(),
+                        book.getStartAddr(),
+                        book.getEndAddr(),
+                        book.getWalker(),
+                        book.getBookStatus(),
+                        book.getPath() == null ? null : PathRes.from(book.getPath())
+                );
+        }
+}

--- a/backend/src/main/java/hyfive/gachita/application/book/dto/QBookWithPathDto.java
+++ b/backend/src/main/java/hyfive/gachita/application/book/dto/QBookWithPathDto.java
@@ -1,0 +1,2 @@
+package hyfive.gachita.application.book.dto;public record QBookWithPathDto() {
+}

--- a/backend/src/main/java/hyfive/gachita/application/book/dto/QBookWithPathDto.java
+++ b/backend/src/main/java/hyfive/gachita/application/book/dto/QBookWithPathDto.java
@@ -1,2 +1,0 @@
-package hyfive.gachita.application.book.dto;public record QBookWithPathDto() {
-}

--- a/backend/src/main/java/hyfive/gachita/application/book/repository/CustomBookRepository.java
+++ b/backend/src/main/java/hyfive/gachita/application/book/repository/CustomBookRepository.java
@@ -16,5 +16,6 @@ public interface CustomBookRepository {
                                          BookStatus status,
                                          Pageable pageable);
     List<Book> findBooksForScroll(BookStatus status, BookCursor cursorId, int size);
+    List<Book> findBooksForScrollWithPath(BookStatus status, BookCursor cursor, int size);
     List<Book> searchCandidates(LocalDate hospitalTime);
 }

--- a/backend/src/main/java/hyfive/gachita/application/book/repository/CustomBookRepository.java
+++ b/backend/src/main/java/hyfive/gachita/application/book/repository/CustomBookRepository.java
@@ -16,6 +16,6 @@ public interface CustomBookRepository {
                                          BookStatus status,
                                          Pageable pageable);
     List<Book> findBooksForScroll(BookStatus status, BookCursor cursorId, int size);
-    List<Book> findBooksForScrollWithPath(BookStatus status, BookCursor cursor, int size);
+    List<Book> findBooksForScrollWithPath(Pair<LocalDateTime, LocalDateTime> dateRange, BookStatus status, BookCursor cursor, int size);
     List<Book> searchCandidates(LocalDate hospitalTime);
 }

--- a/backend/src/main/java/hyfive/gachita/application/book/repository/CustomBookRepositoryImpl.java
+++ b/backend/src/main/java/hyfive/gachita/application/book/repository/CustomBookRepositoryImpl.java
@@ -85,13 +85,16 @@ public class CustomBookRepositoryImpl implements CustomBookRepository {
     }
 
     @Override
-    public List<Book> findBooksForScrollWithPath(BookStatus status, BookCursor cursor, int size) {
+    public List<Book> findBooksForScrollWithPath(Pair<LocalDateTime, LocalDateTime> dateRange, BookStatus status, BookCursor cursor, int size) {
         return queryFactory
                 .select(book)
                 .from(book)
-                .join(book.path, path)
-                .join(path.car, car)
-                .where(book.bookStatus.eq(status))
+                .leftJoin(book.path, path)
+                .leftJoin(path.car, car)
+                .where(
+                        book.bookStatus.eq(status),
+                        betweenCreatedDate(book, dateRange)
+                )
                 .orderBy(book.createdAt.desc(), book.id.desc())
                 .limit(size + 1)
                 .fetch();

--- a/backend/src/main/java/hyfive/gachita/application/book/repository/CustomBookRepositoryImpl.java
+++ b/backend/src/main/java/hyfive/gachita/application/book/repository/CustomBookRepositoryImpl.java
@@ -5,7 +5,6 @@ import com.querydsl.core.types.dsl.Wildcard;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import hyfive.gachita.application.book.Book;
 import hyfive.gachita.application.book.BookStatus;
-
 import hyfive.gachita.application.book.QBook;
 import hyfive.gachita.application.book.dto.BookCursor;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +19,8 @@ import java.time.LocalTime;
 import java.util.List;
 
 import static hyfive.gachita.application.book.QBook.book;
+import static hyfive.gachita.application.car.QCar.car;
+import static hyfive.gachita.application.path.QPath.path;
 
 
 @RequiredArgsConstructor
@@ -78,6 +79,19 @@ public class CustomBookRepositoryImpl implements CustomBookRepository {
                         book.createdAt.between(startOfToday, endOfToday),
                         cursorCondition
                 )
+                .orderBy(book.createdAt.desc(), book.id.desc())
+                .limit(size + 1)
+                .fetch();
+    }
+
+    @Override
+    public List<Book> findBooksForScrollWithPath(BookStatus status, BookCursor cursor, int size) {
+        return queryFactory
+                .select(book)
+                .from(book)
+                .join(book.path, path)
+                .join(path.car, car)
+                .where(book.bookStatus.eq(status))
                 .orderBy(book.createdAt.desc(), book.id.desc())
                 .limit(size + 1)
                 .fetch();

--- a/backend/src/main/java/hyfive/gachita/application/path/PathService.java
+++ b/backend/src/main/java/hyfive/gachita/application/path/PathService.java
@@ -3,6 +3,7 @@ package hyfive.gachita.application.path;
 import hyfive.gachita.application.book.Book;
 import hyfive.gachita.application.node.Node;
 import hyfive.gachita.application.node.NodeType;
+import hyfive.gachita.application.path.dto.PathRes;
 import hyfive.gachita.application.path.respository.PathRepository;
 import hyfive.gachita.dispatch.dto.FinalNewPathDto;
 import lombok.RequiredArgsConstructor;
@@ -50,6 +51,12 @@ public class PathService {
         path.setNodes(nodeList);
         pathRepository.save(path);
     }
+
+    public PathRes getPathByBook(Long bookId) {
+        return pathRepository.findPathResByBookId(bookId)
+                .orElseThrow(() -> new RuntimeException("경로 없음"));
+    }
+
 
     private LocalTime minTime(LocalTime timeA, LocalTime timeB) {
         return timeA.isBefore(timeB) ? timeA : timeB;

--- a/backend/src/main/java/hyfive/gachita/application/path/dto/PathRes.java
+++ b/backend/src/main/java/hyfive/gachita/application/path/dto/PathRes.java
@@ -1,6 +1,7 @@
 package hyfive.gachita.application.path.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
+import hyfive.gachita.application.path.Path;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
@@ -35,5 +36,16 @@ public record PathRes(
                 this.endTime = endTime;
                 this.startAddr = startAddr;
                 this.endAddr = endAddr;
+        }
+
+        public static PathRes from(Path path) {
+                return new PathRes(
+                        path.getId(),
+                        path.getCar().getCarNumber(),
+                        path.getRealStartTime(),
+                        path.getRealEndTime(),
+                        path.getStartAddr(),
+                        path.getEndAddr()
+                );
         }
 }

--- a/backend/src/main/java/hyfive/gachita/application/path/dto/PathRes.java
+++ b/backend/src/main/java/hyfive/gachita/application/path/dto/PathRes.java
@@ -1,0 +1,39 @@
+package hyfive.gachita.application.path.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalTime;
+
+@Builder
+public record PathRes(
+        @Schema(description = "경로 ID", example = "1")
+        Long pathId,
+
+        @Schema(description = "차량 번호", example = "12가 3456")
+        String carNumber,
+
+        @Schema(description = "운행 시작 시간", example = "09:30")
+        LocalTime startTime,
+
+        @Schema(description = "운행 종료 시간", example = "10:45")
+        LocalTime endTime,
+
+        @Schema(description = "출발지 주소", example = "노원로16길 15")
+        String startAddr,
+
+        @Schema(description = "도착지 주소", example = "한글비석로 68")
+        String endAddr
+) {
+        @QueryProjection
+        public PathRes(Long pathId, String carNumber, LocalTime startTime,
+                       LocalTime endTime, String startAddr, String endAddr) {
+                this.pathId = pathId;
+                this.carNumber = carNumber;
+                this.startTime = startTime;
+                this.endTime = endTime;
+                this.startAddr = startAddr;
+                this.endAddr = endAddr;
+        }
+}

--- a/backend/src/main/java/hyfive/gachita/application/path/respository/CustomPathRepository.java
+++ b/backend/src/main/java/hyfive/gachita/application/path/respository/CustomPathRepository.java
@@ -1,10 +1,14 @@
 package hyfive.gachita.application.path.respository;
 
+import hyfive.gachita.application.path.dto.PathRes;
 import hyfive.gachita.dispatch.dto.PathDispatchDto;
 import hyfive.gachita.dispatch.module.condition.PathCondition;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CustomPathRepository {
     List<PathDispatchDto> searchPathList(PathCondition condition);
+
+    Optional<PathRes> findPathResByBookId(Long bookId);
 }

--- a/backend/src/main/java/hyfive/gachita/application/path/respository/CustomPathRepositoryImpl.java
+++ b/backend/src/main/java/hyfive/gachita/application/path/respository/CustomPathRepositoryImpl.java
@@ -2,6 +2,8 @@ package hyfive.gachita.application.path.respository;
 
 import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import hyfive.gachita.application.path.dto.PathRes;
+import hyfive.gachita.application.path.dto.QPathRes;
 import hyfive.gachita.dispatch.dto.NodeDispatchLocationDto;
 import hyfive.gachita.dispatch.dto.PathDispatchDto;
 import hyfive.gachita.dispatch.module.condition.PathCondition;
@@ -11,10 +13,12 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static hyfive.gachita.application.car.QCar.car;
 import static hyfive.gachita.application.node.QNode.node;
 import static hyfive.gachita.application.path.QPath.path;
+import static hyfive.gachita.application.book.QBook.book;
 
 import static java.util.stream.Collectors.*;
 
@@ -50,6 +54,25 @@ public class CustomPathRepositoryImpl implements CustomPathRepository {
                     return createPathDto(pathId, nodeList);
                 })
                 .toList();
+    }
+
+    @Override
+    public Optional<PathRes> findPathResByBookId(Long bookId) {
+        return Optional.ofNullable(queryFactory
+                .select(new QPathRes(
+                        path.id,
+                        car.carNumber,
+                        path.realStartTime,
+                        path.realEndTime,
+                        path.startAddr,
+                        path.endAddr
+                ))
+                .from(book)
+                .join(book.path, path)
+                .join(path.car, car)
+                .where(book.id.eq(bookId))
+                .fetchOne()
+        );
     }
 
     private Map<Long, List<Node>> converToMap(List<Tuple> result) {

--- a/backend/src/main/java/hyfive/gachita/application/path/respository/CustomPathRepositoryImpl.java
+++ b/backend/src/main/java/hyfive/gachita/application/path/respository/CustomPathRepositoryImpl.java
@@ -68,8 +68,8 @@ public class CustomPathRepositoryImpl implements CustomPathRepository {
                         path.endAddr
                 ))
                 .from(book)
-                .join(book.path, path)
-                .join(path.car, car)
+                .leftjoin(book.path, path)
+                .leftjoin(path.car, car)
                 .where(book.id.eq(bookId))
                 .fetchOne()
         );

--- a/backend/src/main/java/hyfive/gachita/dispatch/DispatchService.java
+++ b/backend/src/main/java/hyfive/gachita/dispatch/DispatchService.java
@@ -48,7 +48,7 @@ public class DispatchService {
 
             // 4. 배차 결과 반영
             bookStatus = BookStatus.SUCCESS;
-            bookService.updatePath(newBook.getId(), savedPath);
+            bookService.setPath(newBook.getId(), savedPath);
 
         } catch (Exception e) {
             bookStatus = BookStatus.FAIL;

--- a/backend/src/main/java/hyfive/gachita/dispatch/NewPathDispatchFlow.java
+++ b/backend/src/main/java/hyfive/gachita/dispatch/NewPathDispatchFlow.java
@@ -60,9 +60,9 @@ public class NewPathDispatchFlow {
                 .filter(finalNewPathChecker::isFirstPathDurationExceed)
                 .filter(finalNewPathChecker::isScheduleWithinRentalWindow)
                 .min(Comparator
-                        .comparing(finalNewPathChecker::compareStartTimeDifference)
-                        .thenComparing(FinalNewPathDto::totalDuration)
-                        .thenComparing(FinalNewPathDto::totalDistance)
+                        .comparingInt(finalNewPathChecker::compareStartTimeDifference)
+                        .thenComparingInt(FinalNewPathDto::totalDuration)
+                        .thenComparingInt(FinalNewPathDto::totalDistance)
                 )
                 // TODO: 각 필터에 대한 예외 처리 추가 필요
                 .orElseThrow(()

--- a/backend/src/main/java/hyfive/gachita/docs/BookDocs.java
+++ b/backend/src/main/java/hyfive/gachita/docs/BookDocs.java
@@ -2,6 +2,7 @@ package hyfive.gachita.docs;
 
 import hyfive.gachita.application.book.BookStatus;
 import hyfive.gachita.application.book.dto.BookCursor;
+import hyfive.gachita.application.book.dto.BookWithPathRes;
 import hyfive.gachita.application.common.dto.ScrollRes;
 import hyfive.gachita.application.common.enums.SearchPeriod;
 import hyfive.gachita.application.book.dto.BookRes;
@@ -123,7 +124,7 @@ public interface BookDocs {
                     content = @Content()
             )
     })
-    BaseResponse<ScrollRes<BookRes, BookCursor>> getBookListScroll(
+    BaseResponse<ScrollRes<BookWithPathRes, BookCursor>> getBookListScroll(
             @Parameter(
                     name = "status",
                     description = "예약 상태",

--- a/backend/src/main/java/hyfive/gachita/docs/BookDocs.java
+++ b/backend/src/main/java/hyfive/gachita/docs/BookDocs.java
@@ -11,6 +11,7 @@ import hyfive.gachita.application.common.dto.PagedListRes;
 import hyfive.gachita.global.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
@@ -116,7 +117,46 @@ public interface BookDocs {
             @ApiResponse(
                     responseCode = "1000",
                     description = "조회 성공 시, items에 예약 리스트가 포함되며 다음 페이지 여부와 커서 정보도 포함됩니다.",
-                    content = @Content(schema = @Schema(implementation = ScrollRes.class))
+                    content = @Content(
+                            array = @ArraySchema(schema =
+                            @Schema(implementation = BookWithPathRes.class,
+                                    example = "{\n" +
+                                            "  \"isSuccess\": true,\n" +
+                                            "  \"code\": 1000,\n" +
+                                            "  \"message\": \"요청에 성공했습니다.\",\n" +
+                                            "  \"data\": {\n" +
+                                            "    \"items\": [\n" +
+                                            "      {\n" +
+                                            "        \"id\": 11,\n" +
+                                            "        \"bookName\": \"홍길동\",\n" +
+                                            "        \"bookTel\": \"010-1111-0010\",\n" +
+                                            "        \"bookDate\": \"2025.08.20\",\n" +
+                                            "        \"bookTime\": \"03:28\",\n" +
+                                            "        \"hospitalDate\": \"2025.08.26\",\n" +
+                                            "        \"hospitalTime\": \"10:30\",\n" +
+                                            "        \"startAddr\": \"노원로16길 15\",\n" +
+                                            "        \"endAddr\": \"한글비석로 68\",\n" +
+                                            "        \"walker\": true,\n" +
+                                            "        \"bookStatus\": \"SUCCESS\",\n" +
+                                            "        \"path\": {\n" +
+                                            "          \"pathId\": 1,\n" +
+                                            "          \"carNumber\": \"56다1234\",\n" +
+                                            "          \"startTime\": \"08:59:10\",\n" +
+                                            "          \"endTime\": \"09:30:00\",\n" +
+                                            "          \"startAddr\": \"노원로16길 15\",\n" +
+                                            "          \"endAddr\": \"한글비석로 68\"\n" +
+                                            "        }\n" +
+                                            "      }\n" +
+                                            "    ],\n" +
+                                            "    \"hasNext\": false,\n" +
+                                            "    \"cursor\": {\n" +
+                                            "      \"lastId\": 11,\n" +
+                                            "      \"lastCreatedAt\": \"2025-08-20T03:28:32\"\n" +
+                                            "    }\n" +
+                                            "  }\n" +
+                                            "}"
+                            ))
+                    )
             ),
             @ApiResponse(
                     responseCode = "2000",


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Close #265 
- #276  PR에서부터 작업하였습니다!

## 📝 기능 설명
실시간 예약 현황 조회시 경로 정보를 추가로 전달하도록 구현하였습니다.
아래와 같은 형식으로 경로 정보를 추가로 전달합니다.
```json
{
    "isSuccess": true,
    "code": 1000,
    "message": "요청에 성공했습니다.",
    "data": {
        "items": [
            {
                "id": 11,
                "bookName": "홍길동",
                "bookTel": "010-1111-0010",
                "bookDate": "2025.08.20",
                "bookTime": "03:28",
                "hospitalDate": "2025.08.26",
                "hospitalTime": "10:30",
                "startAddr": "노원로16길 15",
                "endAddr": "한글비석로 68",
                "walker": true,
                "bookStatus": "SUCCESS",
                "path": {
                    "pathId": 1,
                    "carNumber": "56다1234",
                    "startTime": "08:59:10",
                    "endTime": "09:30:00",
                    "startAddr": "노원로16길 15",
                    "endAddr": "한글비석로 68"
                }
            }
        ],
        "hasNext": false,
        "cursor": {
            "lastId": 11,
            "lastCreatedAt": "2025-08-20T03:28:32"
        }
    }
}
```

## 🛠 작업 사항
경로 정보를 전달하는 Dto가 여러개 필요할 것 같은데, 우선은 PathRes로 네이밍하였습니다.
추가적인 DTO가 만들어진다면 그에 따른 변경이 필요할 것 같습니다.


## ✅ 작업 항목
- [x] 구현

## 📎 참고 자료
<!-- 관련 문서, 링크, 스크린샷 등을 첨부해주세요 -->