### PR TITLE
[Fix/#283] 예약 커서 조건 추가

### DIFF
--- a/backend/src/main/java/hyfive/gachita/application/book/repository/CustomBookRepository.java
+++ b/backend/src/main/java/hyfive/gachita/application/book/repository/CustomBookRepository.java
@@ -15,7 +15,6 @@ public interface CustomBookRepository {
     Page<Book> searchBookPageByCondition(Pair<LocalDateTime, LocalDateTime> dateRange,
                                          BookStatus status,
                                          Pageable pageable);
-    List<Book> findBooksForScroll(BookStatus status, BookCursor cursorId, int size);
     List<Book> findBooksForScrollWithPath(Pair<LocalDateTime, LocalDateTime> dateRange, BookStatus status, BookCursor cursor, int size);
     List<Book> searchCandidates(LocalDate hospitalTime);
 }

--- a/backend/src/main/java/hyfive/gachita/application/book/repository/CustomBookRepositoryImpl.java
+++ b/backend/src/main/java/hyfive/gachita/application/book/repository/CustomBookRepositoryImpl.java
@@ -58,34 +58,6 @@ public class CustomBookRepositoryImpl implements CustomBookRepository {
     }
 
     @Override
-    public List<Book> findBooksForScroll(BookStatus status, BookCursor cursor, int size) {
-        LocalDate today = LocalDate.now();
-        LocalDateTime startOfToday = today.atStartOfDay();
-        LocalDateTime endOfToday = today.atTime(LocalTime.MAX);
-
-        BooleanExpression cursorCondition = null;
-
-        if (cursor != null && cursor.lastCreatedAt() != null && cursor.lastId() != null) {
-            cursorCondition = book.createdAt.lt(cursor.lastCreatedAt())
-                    .or(
-                            book.createdAt.eq(cursor.lastCreatedAt())
-                                    .and(book.id.lt(cursor.lastId()))
-                    );
-        }
-
-        return queryFactory
-                .selectFrom(book)
-                .where(
-                        book.bookStatus.eq(status),
-                        book.createdAt.between(startOfToday, endOfToday),
-                        cursorCondition
-                )
-                .orderBy(book.createdAt.desc(), book.id.desc())
-                .limit(size + 1)
-                .fetch();
-    }
-
-    @Override
     public List<Book> findBooksForScrollWithPath(Pair<LocalDateTime, LocalDateTime> dateRange, BookStatus status, BookCursor cursor, int size) {
         BooleanBuilder cursorCondition = new BooleanBuilder();
         if (cursor != null && cursor.lastId() != null && cursor.lastCreatedAt() != null) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Close #283

## 📝 기능 설명
경로 스크롤 조회를 구현하다가 발견한 예약 스크롤 조회의 커서 조건을 추가하였습니다.
- 커서 조건 : 마지막 인덱스로 넘어온 조건 이후의 값들인지 확인 

## 🛠 작업 사항
### 기존 쿼리 수정
최신순 정렬을 해야하므로 커서로 전달된 createdAt의 값보다 더 큰 값인지, 동일하다면 아이디가 더 작은값인지 확인하는 조건을 추가하였습니다.

### 사용하지 않는 메서드 제거

## ✅ 작업 항목
- [x] 쿼리 조건 추가

## 📎 참고 자료
<!-- 관련 문서, 링크, 스크린샷 등을 첨부해주세요 -->