### PR TITLE
[Feat/#225] 실시간 경로 카드 스크롤 조회

### DIFF
--- a/backend/src/main/java/hyfive/gachita/application/path/PathController.java
+++ b/backend/src/main/java/hyfive/gachita/application/path/PathController.java
@@ -3,6 +3,7 @@ package hyfive.gachita.application.path;
 import hyfive.gachita.application.common.dto.ScrollRes;
 import hyfive.gachita.application.path.dto.PathCursor;
 import hyfive.gachita.application.path.dto.PathDetailRes;
+import hyfive.gachita.docs.PathDocs;
 import hyfive.gachita.global.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -10,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/path")
 @RequiredArgsConstructor
-public class PathController {
+public class PathController implements PathDocs {
     private final PathService pathService;
 
     @GetMapping("/scroll")

--- a/backend/src/main/java/hyfive/gachita/application/path/PathController.java
+++ b/backend/src/main/java/hyfive/gachita/application/path/PathController.java
@@ -1,12 +1,24 @@
 package hyfive.gachita.application.path;
 
+import hyfive.gachita.application.common.dto.ScrollRes;
+import hyfive.gachita.application.path.dto.PathCursor;
+import hyfive.gachita.application.path.dto.PathDetailRes;
+import hyfive.gachita.global.BaseResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/path")
 @RequiredArgsConstructor
 public class PathController {
     private final PathService pathService;
+
+    @GetMapping("/scroll")
+    public BaseResponse<ScrollRes<PathDetailRes, PathCursor>> getPathListScroll(
+            @RequestParam(name = "status", defaultValue = "WAITING") DriveStatus status,
+            @ModelAttribute PathCursor cursor,
+            @RequestParam(name = "size", defaultValue = "10") int size
+    ) {
+        return BaseResponse.success(pathService.getPathListScroll(status, cursor, size));
+    }
 }

--- a/backend/src/main/java/hyfive/gachita/application/path/PathService.java
+++ b/backend/src/main/java/hyfive/gachita/application/path/PathService.java
@@ -1,8 +1,11 @@
 package hyfive.gachita.application.path;
 
 import hyfive.gachita.application.book.Book;
+import hyfive.gachita.application.common.dto.ScrollRes;
 import hyfive.gachita.application.node.Node;
 import hyfive.gachita.application.node.NodeType;
+import hyfive.gachita.application.path.dto.PathCursor;
+import hyfive.gachita.application.path.dto.PathDetailRes;
 import hyfive.gachita.application.path.dto.PathRes;
 import hyfive.gachita.application.path.respository.PathRepository;
 import hyfive.gachita.dispatch.dto.FinalNewPathDto;
@@ -10,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
 
@@ -57,11 +61,36 @@ public class PathService {
                 .orElseThrow(() -> new RuntimeException("경로 없음"));
     }
 
+    public ScrollRes<PathDetailRes, PathCursor> getPathListScroll(DriveStatus status, PathCursor cursor, int size) {
+        List<Path> pathList = pathRepository.findPathsForScroll(LocalDate.now(), status, cursor, size);
+
+        boolean hasNext = pathList.size() > size;
+
+        List<Path> actualList = hasNext ? pathList.subList(0, size) : pathList;
+
+        List<PathDetailRes> pathResList = actualList.stream()
+                .map(PathDetailRes::from)
+                .toList();
+
+        PathCursor lastCursor = null;
+        if (!actualList.isEmpty()) {
+            Path lastPath = actualList.get(actualList.size() - 1);
+            lastCursor = PathCursor.builder()
+                    .lastId(lastPath.getId())
+                    .lastStartTime(lastPath.getRealStartTime())
+                    .lastEndTime(lastPath.getRealEndTime()
+                    )
+                    .build();
+        }
+
+        return ScrollRes.<PathDetailRes, PathCursor>builder()
+                .items(pathResList)
+                .hasNext(hasNext)
+                .cursor(lastCursor)
+                .build();
+    }
 
     private LocalTime minTime(LocalTime timeA, LocalTime timeB) {
         return timeA.isBefore(timeB) ? timeA : timeB;
     }
 }
-
-
-

--- a/backend/src/main/java/hyfive/gachita/application/path/dto/PathCursor.java
+++ b/backend/src/main/java/hyfive/gachita/application/path/dto/PathCursor.java
@@ -1,5 +1,6 @@
 package hyfive.gachita.application.path.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 
 import java.time.LocalTime;
@@ -7,6 +8,10 @@ import java.time.LocalTime;
 @Builder
 public record PathCursor(
         Long lastId,
+
+        @JsonFormat(pattern = "HH:mm")
         LocalTime lastStartTime,
+
+        @JsonFormat(pattern = "HH:mm")
         LocalTime lastEndTime
 ) {}

--- a/backend/src/main/java/hyfive/gachita/application/path/dto/PathCursor.java
+++ b/backend/src/main/java/hyfive/gachita/application/path/dto/PathCursor.java
@@ -1,0 +1,12 @@
+package hyfive.gachita.application.path.dto;
+
+import lombok.Builder;
+
+import java.time.LocalTime;
+
+@Builder
+public record PathCursor(
+        Long lastId,
+        LocalTime lastStartTime,
+        LocalTime lastEndTime
+) {}

--- a/backend/src/main/java/hyfive/gachita/application/path/dto/PathDetailRes.java
+++ b/backend/src/main/java/hyfive/gachita/application/path/dto/PathDetailRes.java
@@ -1,0 +1,56 @@
+package hyfive.gachita.application.path.dto;
+
+import hyfive.gachita.application.path.DriveStatus;
+import hyfive.gachita.application.path.Path;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalTime;
+
+@Builder
+public record PathDetailRes(
+        @Schema(description = "경로 ID", example = "1")
+        Long pathId,
+
+        @Schema(description = "차량 번호", example = "12가 3456")
+        String carNumber,
+
+        @Schema(description = "운행 시작 시간", example = "09:30")
+        LocalTime startTime,
+
+        @Schema(description = "운행 종료 시간", example = "10:45")
+        LocalTime endTime,
+
+        @Schema(description = "출발지 주소", example = "노원로16길 15")
+        String startAddr,
+
+        @Schema(description = "도착지 주소", example = "한글비석로 68")
+        String endAddr,
+
+        @Schema(description = "센터 이름", example = "노원센터")
+        String centerName,
+
+        @Schema(description = "운행 상태", example = "WAITING, RUNNING, FINISHED")
+        DriveStatus driveStatus,
+
+        @Schema(description = "탑승자 수", example = "3")
+        int userCount,
+
+        @Schema(description = "차량 정원", example = "4")
+        int capacity
+) {
+        public static PathDetailRes from(Path path) {
+                return new PathDetailRes(
+                        path.getId(),
+                        path.getCar().getCarNumber(),
+                        path.getRealStartTime(),
+                        path.getRealEndTime(),
+                        path.getStartAddr(),
+                        path.getEndAddr(),
+                        path.getCar().getCenter().getCenterName(),
+                        path.getDriveStatus(),
+                        path.getUserCount(),
+                        path.getCar().getCapacity()
+                );
+        }
+}

--- a/backend/src/main/java/hyfive/gachita/application/path/dto/PathDetailRes.java
+++ b/backend/src/main/java/hyfive/gachita/application/path/dto/PathDetailRes.java
@@ -34,10 +34,7 @@ public record PathDetailRes(
         DriveStatus driveStatus,
 
         @Schema(description = "탑승자 수", example = "3")
-        int userCount,
-
-        @Schema(description = "차량 정원", example = "4")
-        int capacity
+        int userCount
 ) {
         public static PathDetailRes from(Path path) {
                 return new PathDetailRes(
@@ -49,8 +46,7 @@ public record PathDetailRes(
                         path.getEndAddr(),
                         path.getCar().getCenter().getCenterName(),
                         path.getDriveStatus(),
-                        path.getUserCount(),
-                        path.getCar().getCapacity()
+                        path.getUserCount()
                 );
         }
 }

--- a/backend/src/main/java/hyfive/gachita/application/path/dto/PathDetailRes.java
+++ b/backend/src/main/java/hyfive/gachita/application/path/dto/PathDetailRes.java
@@ -1,5 +1,6 @@
 package hyfive.gachita.application.path.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import hyfive.gachita.application.path.DriveStatus;
 import hyfive.gachita.application.path.Path;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -16,9 +17,11 @@ public record PathDetailRes(
         String carNumber,
 
         @Schema(description = "운행 시작 시간", example = "09:30")
+        @JsonFormat(pattern = "HH:mm")
         LocalTime startTime,
 
         @Schema(description = "운행 종료 시간", example = "10:45")
+        @JsonFormat(pattern = "HH:mm")
         LocalTime endTime,
 
         @Schema(description = "출발지 주소", example = "노원로16길 15")

--- a/backend/src/main/java/hyfive/gachita/application/path/respository/CustomPathRepository.java
+++ b/backend/src/main/java/hyfive/gachita/application/path/respository/CustomPathRepository.java
@@ -1,13 +1,18 @@
 package hyfive.gachita.application.path.respository;
 
+import hyfive.gachita.application.path.DriveStatus;
+import hyfive.gachita.application.path.Path;
+import hyfive.gachita.application.path.dto.PathCursor;
 import hyfive.gachita.application.path.dto.PathRes;
 import hyfive.gachita.dispatch.dto.OldPathDto;
 import hyfive.gachita.dispatch.module.condition.PathCondition;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
 public interface CustomPathRepository {
     List<OldPathDto> searchPathList(PathCondition condition);
     Optional<PathRes> findPathResByBookId(Long bookId);
+    List<Path> findPathsForScroll(LocalDate date, DriveStatus status, PathCursor cursor, int size);
 }

--- a/backend/src/main/java/hyfive/gachita/docs/PathDocs.java
+++ b/backend/src/main/java/hyfive/gachita/docs/PathDocs.java
@@ -1,0 +1,55 @@
+package hyfive.gachita.docs;
+
+import hyfive.gachita.application.common.dto.ScrollRes;
+import hyfive.gachita.application.path.DriveStatus;
+import hyfive.gachita.application.path.dto.PathCursor;
+import hyfive.gachita.application.path.dto.PathDetailRes;
+import hyfive.gachita.global.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "경로 API", description = "경로 조회 및 관리 API")
+public interface PathDocs {
+
+    @Operation(
+            summary = "경로 스크롤 조회",
+            description = "커서 기반 스크롤 방식으로 오늘의 실시간 경로 목록을 조회합니다. " +
+                    "status(운행 상태), cursor(마지막 조회 위치), size(조회 개수)를 기준으로 다음 페이지 데이터를 반환합니다."
+    )
+    @ApiResponse(
+            responseCode = "1000",
+            description = "성공적으로 경로 목록을 조회함",
+            content = @Content(
+                    schema = @Schema(implementation = ScrollRes.class)
+            )
+    )
+    BaseResponse<ScrollRes<PathDetailRes, PathCursor>> getPathListScroll(
+            @Parameter(
+                    description = """
+                    운행 상태 (WAITING, RUNNING, FINISHED)
+                    ** 실제 요청시에는 `localhost:8080/api/path/scroll?status=waiting&size=3&lastId=2&lastStartTime=09:59:10&lastEndTime=09:30:00` 와 같이 쿼리 파라미터 형식으로 요청 가능합니다!**
+                    커서의 필드를 모두 전달하지 않거나 커서의 필드가 비어있으면, 가장 최근의 경로부터 조회됩니다.
+                    """,
+                    example = "WAITING"
+            )
+            @RequestParam(name = "status", defaultValue = "WAITING") DriveStatus status,
+
+            @Parameter(
+                    description = "커서 정보 (마지막으로 조회된 경로 위치)",
+                    required = false
+            )
+            @ModelAttribute PathCursor cursor,
+
+            @Parameter(
+                    description = "조회할 데이터 개수",
+                    example = "10"
+            )
+            @RequestParam(name = "size", defaultValue = "10") int size
+    );
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Close #225

## 📝 기능 설명
- 운행 시작시간, 운행 종료 시간, id 값을 기준으로 정렬하여 제공합니다.
API 형식 `GET /api/path/scroll?status=waiting&size=3&lastId=&lastStartTime=&lastEndTime=`

## 🛠 작업 사항
### 피그마와 달라진 점
피그마에서는 `5 / 8`  과 같은 형식으로 실시간 탑승 인원수와 예약한 인원수를 표시하지만, 현재는 실시간 탑승 인원수를 표기할 수 없기 때문에, 예약 인원수만을 표기합니다.

## ✅ 작업 항목
- [x] 구현
- [x] 스웨거 문서 작성

## 📎 참고 자료
<!-- 관련 문서, 링크, 스크린샷 등을 첨부해주세요 -->