### PR TITLE
[Feat/#226] 경로 운행정보 리스트 조회

### DIFF
--- a/backend/src/main/java/hyfive/gachita/application/book/BookController.java
+++ b/backend/src/main/java/hyfive/gachita/application/book/BookController.java
@@ -29,7 +29,7 @@ public class BookController implements BookDocs {
     @GetMapping("/list")
     public BaseResponse<PagedListRes<BookRes>> getBookList(
             @RequestParam(name = "period", required = false, defaultValue = "TODAY") SearchPeriod period,
-            @RequestParam(name = "status") BookStatus bookStatus,
+            @RequestParam(name = "status", required = false) BookStatus bookStatus,
             @RequestParam(name = "page", required = false, defaultValue = "1") int page,
             @RequestParam(name = "limit", required = false, defaultValue = "12") int limit
     ) {

--- a/backend/src/main/java/hyfive/gachita/application/path/PathController.java
+++ b/backend/src/main/java/hyfive/gachita/application/path/PathController.java
@@ -1,6 +1,8 @@
 package hyfive.gachita.application.path;
 
+import hyfive.gachita.application.common.dto.PagedListRes;
 import hyfive.gachita.application.common.dto.ScrollRes;
+import hyfive.gachita.application.common.enums.SearchPeriod;
 import hyfive.gachita.application.path.dto.PassengerRes;
 import hyfive.gachita.application.path.dto.PathCursor;
 import hyfive.gachita.application.path.dto.PathDetailRes;
@@ -29,5 +31,15 @@ public class PathController implements PathDocs {
             @RequestParam(name = "size", defaultValue = "10") int size
     ) {
         return BaseResponse.success(pathService.getPathListScroll(status, cursor, size));
+    }
+
+    @GetMapping("/list")
+    public BaseResponse<PagedListRes<PathDetailRes>> getPathList(
+            @RequestParam(name = "period", required = false, defaultValue = "TODAY") SearchPeriod period,
+            @RequestParam(name = "status") DriveStatus status,
+            @RequestParam(name = "page", required = false, defaultValue = "1") int page,
+            @RequestParam(name = "limit", required = false, defaultValue = "12") int limit
+    ) {
+        return BaseResponse.success(pathService.getPathList(period, status, page, limit));
     }
 }

--- a/backend/src/main/java/hyfive/gachita/application/path/PathController.java
+++ b/backend/src/main/java/hyfive/gachita/application/path/PathController.java
@@ -8,6 +8,8 @@ import hyfive.gachita.application.path.dto.PathCursor;
 import hyfive.gachita.application.path.dto.PathDetailRes;
 import hyfive.gachita.docs.PathDocs;
 import hyfive.gachita.global.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -33,10 +35,14 @@ public class PathController implements PathDocs {
         return BaseResponse.success(pathService.getPathListScroll(status, cursor, size));
     }
 
+    @Operation(summary = "경로 리스트 조회 API", description = """
+            기간(period), 상태(status)를 조건으로 경로 리스트를 조회합니다. 
+            페이지네이션(page, limit) 방식으로 결과를 제공합니다.
+            """)
     @GetMapping("/list")
     public BaseResponse<PagedListRes<PathDetailRes>> getPathList(
             @RequestParam(name = "period", required = false, defaultValue = "TODAY") SearchPeriod period,
-            @RequestParam(name = "status") DriveStatus status,
+            @RequestParam(name = "status", required = false) DriveStatus status,
             @RequestParam(name = "page", required = false, defaultValue = "1") int page,
             @RequestParam(name = "limit", required = false, defaultValue = "12") int limit
     ) {

--- a/backend/src/main/java/hyfive/gachita/application/path/PathService.java
+++ b/backend/src/main/java/hyfive/gachita/application/path/PathService.java
@@ -1,7 +1,11 @@
 package hyfive.gachita.application.path;
 
 import hyfive.gachita.application.book.Book;
+import hyfive.gachita.application.book.dto.BookRes;
+import hyfive.gachita.application.common.dto.PagedListRes;
 import hyfive.gachita.application.common.dto.ScrollRes;
+import hyfive.gachita.application.common.enums.SearchPeriod;
+import hyfive.gachita.application.common.util.DateRangeUtil;
 import hyfive.gachita.application.node.Node;
 import hyfive.gachita.application.node.NodeType;
 import hyfive.gachita.application.path.dto.PassengerRes;
@@ -13,10 +17,15 @@ import hyfive.gachita.dispatch.dto.FinalNewPathDto;
 import hyfive.gachita.global.BusinessException;
 import hyfive.gachita.global.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Comparator;
 import java.util.List;
@@ -123,6 +132,23 @@ public class PathService {
                 .items(pathResList)
                 .hasNext(hasNext)
                 .cursor(lastCursor)
+                .build();
+    }
+
+    public PagedListRes<PathDetailRes> getPathList(SearchPeriod period, DriveStatus status, int page, int limit) {
+        Pageable pageable = PageRequest.of(
+                page - 1,
+                limit
+        );
+
+        Pair<LocalDate, LocalDate> dateRange = DateRangeUtil.getDateRange(LocalDate.now(), period);
+        Page<Path> pageResult = pathRepository.searchPathPageByCondition(dateRange, status, pageable);
+        List<PathDetailRes> pathResList = pageResult.getContent().stream().map(PathDetailRes::from).toList();
+        return PagedListRes.<PathDetailRes>builder()
+                .items(pathResList)
+                .currentPageNum(pageResult.getNumber() + 1)
+                .totalPageNum(pageResult.getTotalPages())
+                .totalItemNum(pageResult.getTotalElements())
                 .build();
     }
 

--- a/backend/src/main/java/hyfive/gachita/application/path/respository/CustomPathRepository.java
+++ b/backend/src/main/java/hyfive/gachita/application/path/respository/CustomPathRepository.java
@@ -6,8 +6,12 @@ import hyfive.gachita.application.path.dto.PathCursor;
 import hyfive.gachita.application.path.dto.PathRes;
 import hyfive.gachita.dispatch.dto.OldPathDto;
 import hyfive.gachita.dispatch.module.condition.PathCondition;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.util.Pair;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -16,4 +20,7 @@ public interface CustomPathRepository {
     Optional<PathRes> findPathResByBookId(Long bookId);
     Path findPassengersByPathId(Long pathId);
     List<Path> findPathsForScroll(LocalDate date, DriveStatus status, PathCursor cursor, int size);
+    Page<Path> searchPathPageByCondition(Pair<LocalDate, LocalDate> dateRange,
+                                         DriveStatus status,
+                                         Pageable pageable);
 }

--- a/backend/src/main/java/hyfive/gachita/application/path/respository/CustomPathRepositoryImpl.java
+++ b/backend/src/main/java/hyfive/gachita/application/path/respository/CustomPathRepositoryImpl.java
@@ -2,11 +2,13 @@ package hyfive.gachita.application.path.respository;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Wildcard;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import hyfive.gachita.application.car.DelYn;
-import hyfive.gachita.application.path.Path;
 import hyfive.gachita.application.path.DriveStatus;
+import hyfive.gachita.application.path.Path;
+import hyfive.gachita.application.path.QPath;
 import hyfive.gachita.application.path.dto.PathCursor;
 import hyfive.gachita.application.path.dto.PathRes;
 import hyfive.gachita.dispatch.dto.OldPathDto;
@@ -19,7 +21,6 @@ import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -145,7 +146,7 @@ public class CustomPathRepositoryImpl implements CustomPathRepository {
                 .from(path)
                 .where(
                         path.driveDate.between(dateRange.getFirst(), dateRange.getSecond()),
-                        path.driveStatus.eq(status)
+                        statusEq(path, status)
                 )
                 .orderBy(
                     path.realStartTime.asc(),
@@ -161,10 +162,14 @@ public class CustomPathRepositoryImpl implements CustomPathRepository {
                 .from(path)
                 .where(
                         path.driveDate.between(dateRange.getFirst(), dateRange.getSecond()),
-                        path.driveStatus.eq(status)
+                        statusEq(path, status)
                 )
                 .fetchOne();
 
         return new PageImpl<>(pathList, pageable, totalCount == null ? 0L : totalCount);
+    }
+
+    private BooleanExpression statusEq(QPath path, DriveStatus status) {
+        return status != null ? path.driveStatus.eq(status) : null;
     }
 }

--- a/backend/src/main/java/hyfive/gachita/application/path/respository/CustomPathRepositoryImpl.java
+++ b/backend/src/main/java/hyfive/gachita/application/path/respository/CustomPathRepositoryImpl.java
@@ -2,6 +2,7 @@ package hyfive.gachita.application.path.respository;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Wildcard;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import hyfive.gachita.application.car.DelYn;
 import hyfive.gachita.application.path.Path;
@@ -11,9 +12,14 @@ import hyfive.gachita.application.path.dto.PathRes;
 import hyfive.gachita.dispatch.dto.OldPathDto;
 import hyfive.gachita.dispatch.module.condition.PathCondition;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -128,5 +134,37 @@ public class CustomPathRepositoryImpl implements CustomPathRepository {
                 .leftJoin(book.nodeList, node)
                 .where(path.id.eq(pathId))
                 .fetchOne();
+    }
+
+    @Override
+    public Page<Path> searchPathPageByCondition(Pair<LocalDate, LocalDate> dateRange,
+                                                DriveStatus status,
+                                                Pageable pageable) {
+        List<Path> pathList = queryFactory
+                .select(path)
+                .from(path)
+                .where(
+                        path.driveDate.between(dateRange.getFirst(), dateRange.getSecond()),
+                        path.driveStatus.eq(status)
+                )
+                .orderBy(
+                    path.realStartTime.asc(),
+                    path.realEndTime.asc(),
+                    path.id.desc()
+                )
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long totalCount = queryFactory
+                .select(Wildcard.count)
+                .from(path)
+                .where(
+                        path.driveDate.between(dateRange.getFirst(), dateRange.getSecond()),
+                        path.driveStatus.eq(status)
+                )
+                .fetchOne();
+
+        return new PageImpl<>(pathList, pageable, totalCount == null ? 0L : totalCount);
     }
 }

--- a/backend/src/main/java/hyfive/gachita/docs/PathDocs.java
+++ b/backend/src/main/java/hyfive/gachita/docs/PathDocs.java
@@ -1,5 +1,7 @@
 package hyfive.gachita.docs;
 
+import hyfive.gachita.application.common.dto.PagedListRes;
+import hyfive.gachita.application.common.enums.SearchPeriod;
 import hyfive.gachita.application.path.dto.PassengerRes;
 import hyfive.gachita.application.common.dto.ScrollRes;
 import hyfive.gachita.application.path.DriveStatus;
@@ -11,7 +13,9 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -75,5 +79,52 @@ public interface PathDocs {
                     example = "10"
             )
             @RequestParam(name = "size", defaultValue = "10") int size
+    );
+
+    @Operation(
+            summary = "경로 리스트 조회 API",
+            description = """
+            기간(period), 상태(status)를 조건으로 경로 리스트를 조회합니다. 
+            페이지네이션(page, limit) 방식으로 결과를 제공합니다.
+            """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "1000",
+                    description = "조회 성공, items에 PathDetailRes 리스트가 담겨 반환됩니다.",
+                    content = @Content(
+                            schema = @Schema(implementation = PagedListRes.class)
+                    )
+            ),
+    })
+    @GetMapping("/list")
+    BaseResponse<PagedListRes<PathDetailRes>> getPathList(
+            @Parameter(
+                    name = "period",
+                    description = "조회 기간 (TODAY, YESTERDAY, WEEK, MONTH / 기본값: TODAY)",
+                    example = "TODAY"
+            )
+            @RequestParam(name = "period", required = false, defaultValue = "TODAY") SearchPeriod period,
+
+            @Parameter(
+                    name = "status",
+                    description = "운행 상태 (WAITING, RUNNING, FINISHED) / null 또는 비어있는 값으로 요청하면 전체 상태를 조회",
+                    example = "WAITING"
+            )
+            @RequestParam(name = "status", required = false) DriveStatus status,
+
+            @Parameter(
+                    name = "page",
+                    description = "페이지 번호 (기본값: 1)",
+                    example = "1"
+            )
+            @RequestParam(name = "page", required = false, defaultValue = "1") int page,
+
+            @Parameter(
+                    name = "limit",
+                    description = "페이지당 항목 수 (기본값: 12)",
+                    example = "12"
+            )
+            @RequestParam(name = "limit", required = false, defaultValue = "12") int limit
     );
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Close #226 

## 📝 기능 설명
`/api/path/list?period=month&status=waiting&page=2&limit=12`
운행 기간 `period`, 운행 상태 `status` 설정에 따른 경로 정보를 페이지네이션으로 제공합니다.
page는 1번부터 페이지 조회가 가능합니다.
모든 쿼리 파라미터는 필수가 아니며, 작성하지 않는 경우 기본값으로 설정됩니다.

기본값
- period : today
- status : x -> status는 비어있는 경우, 운행 상태와 무관하게 모든 경로 조회
- page : 1
- limit : 2

## 🛠 작업 사항
- 예약리스트 status required=false설정
추가로, 동일하게 동작하는 예약 리스트 조회API의 운행상태의 요청값이 required로 설정되어있는 오류를 발견하여,
해당 PR에서 수정하였습니다.

## ✅ 작업 항목
- [ ] 구현
- [ ] swagger작성
- [ ] book/list 수정

## 📎 참고 자료
<!-- 관련 문서, 링크, 스크린샷 등을 첨부해주세요 -->