### PR TITLE
[Feat/#282] Kakao 장소 검색 API 연동

### DIFF
--- a/frontend/src/apis/KakaoSearchAPI.ts
+++ b/frontend/src/apis/KakaoSearchAPI.ts
@@ -28,7 +28,7 @@ export const fetchKakaoSearch = async ({
     throw new Error("Kakao REST API key를 찾지 못했어요");
   }
 
-  const safeRadius = radius ? Math.min(radius, 20000) : undefined;
+  const safeRadius = radius ? Math.min(radius, 20000) : 20000;
 
   url.searchParams.set("query", query);
   url.searchParams.set("page", String(page));

--- a/frontend/src/apis/KakaoSearchAPI.ts
+++ b/frontend/src/apis/KakaoSearchAPI.ts
@@ -1,0 +1,66 @@
+import type { KakaoKeywordResponse } from "@/types/kakaoSearch.types";
+
+type KakaoSearchParams = {
+  query: string;
+  page?: number; // 1~45
+  size?: number; // 1~15
+  x?: number; // 경도
+  y?: number; // 위도
+  radius?: number; // m (최대 20000)
+  sort?: "accuracy" | "distance";
+  signal?: AbortSignal;
+};
+const KAKAO_KEY = import.meta.env.VITE_KAKAO_REST_API_KEY;
+if (!KAKAO_KEY) {
+  throw new Error("Kakao REST API key를 찾지 못했어요");
+}
+
+export const fetchKakaoSearch = async ({
+  query,
+  page = 1,
+  size = 10,
+  x,
+  y,
+  radius,
+  sort,
+  signal,
+}: KakaoSearchParams): Promise<KakaoKeywordResponse> => {
+  const url = new URL("https://dapi.kakao.com/v2/local/search/keyword.json");
+  const safeRadius = radius ? Math.min(radius, 20000) : undefined;
+
+  url.searchParams.set("query", query);
+  url.searchParams.set("page", String(page));
+  url.searchParams.set("size", String(size));
+  if (x && y) {
+    url.searchParams.set("x", String(x));
+    url.searchParams.set("y", String(y));
+    if (safeRadius) url.searchParams.set("radius", String(safeRadius));
+    if (sort) url.searchParams.set("sort", sort);
+  }
+
+  const response = await fetch(url.toString(), {
+    method: "GET",
+    headers: {
+      Authorization: `KakaoAK ${KAKAO_KEY}`,
+    },
+    signal,
+  });
+
+  if (!response.ok) {
+    const msg = () => {
+      switch (response.status) {
+        case 401:
+          return "Kakao 인증에 문제가 있어요(401)";
+        case 403:
+          return "Kakao API 접근이 거부되었어요(403)";
+        case 429:
+          return "요청이 너무 많아요(429)";
+        default:
+          return `Kakao API 에러(${response.status})`;
+      }
+    };
+    throw new Error(msg());
+  }
+
+  return (await response.json()) as KakaoKeywordResponse;
+};

--- a/frontend/src/apis/KakaoSearchAPI.ts
+++ b/frontend/src/apis/KakaoSearchAPI.ts
@@ -10,10 +10,6 @@ type KakaoSearchParams = {
   sort?: "accuracy" | "distance";
   signal?: AbortSignal;
 };
-const KAKAO_KEY = import.meta.env.VITE_KAKAO_REST_API_KEY;
-if (!KAKAO_KEY) {
-  throw new Error("Kakao REST API key를 찾지 못했어요");
-}
 
 export const fetchKakaoSearch = async ({
   query,
@@ -26,6 +22,12 @@ export const fetchKakaoSearch = async ({
   signal,
 }: KakaoSearchParams): Promise<KakaoKeywordResponse> => {
   const url = new URL("https://dapi.kakao.com/v2/local/search/keyword.json");
+
+  const KAKAO_KEY = import.meta.env.VITE_KAKAO_REST_API_KEY;
+  if (!KAKAO_KEY) {
+    throw new Error("Kakao REST API key를 찾지 못했어요");
+  }
+
   const safeRadius = radius ? Math.min(radius, 20000) : undefined;
 
   url.searchParams.set("query", query);

--- a/frontend/src/components/Input.tsx
+++ b/frontend/src/components/Input.tsx
@@ -14,6 +14,8 @@ interface InputProps {
   readOnly?: boolean;
   value?: string;
   onClick?: () => void;
+  onFocus?: () => void;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   register?: UseFormRegisterReturn;
   errorMessage?: string;
 }
@@ -27,6 +29,8 @@ const Input = ({
   value,
   readOnly = false,
   onClick,
+  onFocus,
+  onChange,
   register,
   errorMessage = "",
 }: InputProps) => {
@@ -48,13 +52,17 @@ const Input = ({
           css={StyledInput(isFocused, readOnly, errorMessage)}
           type="text"
           placeholder={placeholder}
-          onFocus={() => setIsFocused(true)}
+          onFocus={() => {
+            setIsFocused(true);
+            onFocus?.();
+          }}
           onBlur={(e) => {
             setIsFocused(false);
             void rhfOnBlur(e); //onBlur 덮어쓰기 문제 해결 위한 이벤트 병합
           }}
           readOnly={readOnly}
           onClick={onClick}
+          onChange={onChange}
           value={value}
           {...restRegister}
         />

--- a/frontend/src/components/LoadingSpinner.tsx
+++ b/frontend/src/components/LoadingSpinner.tsx
@@ -1,5 +1,6 @@
-import { css, keyframes } from "@emotion/react";
+import { css } from "@emotion/react";
 import { theme } from "@/styles/themes.style";
+import { rotating } from "@/features/refetchTimer/rotateAnimation.util";
 
 const { color } = theme;
 
@@ -21,16 +22,6 @@ const LoadingSpinner = ({
 
 export default LoadingSpinner;
 
-// 회전 애니메이션
-const spin = keyframes`
-  0% {
-    transform: rotate(0deg);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
-`;
-
 // 컨테이너 스타일
 const SpinnerContainer = (size: "small" | "medium" | "large") => css`
   display: flex;
@@ -48,7 +39,7 @@ const Spinner = (
   border-top: ${getSizeStyles(size).borderWidth} solid ${spinnerColor};
   border-radius: 50%;
   ${getSizeStyles(size).spinner}
-  animation: ${spin} 1s linear infinite;
+  ${rotating(true)}
 `;
 
 // 크기별 스타일

--- a/frontend/src/components/LoadingSpinner.tsx
+++ b/frontend/src/components/LoadingSpinner.tsx
@@ -1,0 +1,93 @@
+import { css, keyframes } from "@emotion/react";
+import { theme } from "@/styles/themes.style";
+
+const { color } = theme;
+
+interface LoadingSpinnerProps {
+  size?: "small" | "medium" | "large";
+  color?: string;
+}
+
+const LoadingSpinner = ({
+  size = "medium",
+  color: spinnerColor = color.Maincolor.primary,
+}: LoadingSpinnerProps) => {
+  return (
+    <div css={SpinnerContainer(size)}>
+      <div css={Spinner(size, spinnerColor)} />
+    </div>
+  );
+};
+
+export default LoadingSpinner;
+
+// 회전 애니메이션
+const spin = keyframes`
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+`;
+
+// 컨테이너 스타일
+const SpinnerContainer = (size: "small" | "medium" | "large") => css`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  ${getSizeStyles(size).container}
+`;
+
+// 스피너 스타일
+const Spinner = (
+  size: "small" | "medium" | "large",
+  spinnerColor: string,
+) => css`
+  border: ${getSizeStyles(size).borderWidth} solid ${color.GrayScale.gray2};
+  border-top: ${getSizeStyles(size).borderWidth} solid ${spinnerColor};
+  border-radius: 50%;
+  ${getSizeStyles(size).spinner}
+  animation: ${spin} 1s linear infinite;
+`;
+
+// 크기별 스타일
+const getSizeStyles = (size: "small" | "medium" | "large") => {
+  const styles = {
+    small: {
+      container: css`
+        width: 16px;
+        height: 16px;
+      `,
+      spinner: css`
+        width: 16px;
+        height: 16px;
+      `,
+      borderWidth: "2px",
+    },
+    medium: {
+      container: css`
+        width: 24px;
+        height: 24px;
+      `,
+      spinner: css`
+        width: 24px;
+        height: 24px;
+      `,
+      borderWidth: "3px",
+    },
+    large: {
+      container: css`
+        width: 32px;
+        height: 32px;
+      `,
+      spinner: css`
+        width: 32px;
+        height: 32px;
+      `,
+      borderWidth: "4px",
+    },
+  };
+
+  return styles[size];
+};

--- a/frontend/src/features/addressInput/AddressDropdown.tsx
+++ b/frontend/src/features/addressInput/AddressDropdown.tsx
@@ -1,5 +1,6 @@
-import { CloseIcon, LocationIcon } from "@/assets/icons";
+import { CloseIcon, InfoIcon, LocationIcon } from "@/assets/icons";
 import { theme } from "@/styles/themes.style";
+import LoadingSpinner from "@/components/LoadingSpinner";
 import {
   DropdownContainer,
   DropdownHeader,
@@ -10,12 +11,14 @@ import {
   DropdownText,
   DropdownTextName,
   DropdownTextAddr,
+  NoContentText,
+  LoadingContent,
 } from "./AddressInput.style";
 
 const { color } = theme;
 
 export interface AddressItem {
-  id: number;
+  id: string;
   name: string;
   addr: string;
 }
@@ -23,6 +26,8 @@ export interface AddressItem {
 interface AddressDropdownProps {
   type: "departure" | "destination";
   results: AddressItem[];
+  isLoading?: boolean;
+  error?: string | null;
   onItemSelect: (item: AddressItem) => void;
   onClose: () => void;
 }
@@ -30,6 +35,8 @@ interface AddressDropdownProps {
 const AddressDropdown = ({
   type,
   results,
+  isLoading = false,
+  error = null,
   onItemSelect,
   onClose,
 }: AddressDropdownProps) => {
@@ -44,19 +51,36 @@ const AddressDropdown = ({
         </button>
       </header>
       <div css={DropdownContentList}>
-        {results.map((item) => (
-          <button
-            key={item.id}
-            css={DropdownContent}
-            onClick={() => onItemSelect(item)}
-          >
-            <LocationIcon fill={color.GrayScale.gray4} />
-            <div css={DropdownText}>
-              <p css={DropdownTextName}>{item.name}</p>
-              <p css={DropdownTextAddr}>{item.addr}</p>
-            </div>
-          </button>
-        ))}
+        {isLoading ? (
+          <div css={LoadingContent}>
+            <LoadingSpinner size="small" />
+            <p css={NoContentText}>잠시만 기다려주세요</p>
+          </div>
+        ) : error ? (
+          <div css={DropdownContent}>
+            <InfoIcon fill={color.GrayScale.gray4} />
+            <p css={NoContentText}>{error}</p>
+          </div>
+        ) : results.length > 0 ? (
+          results.map((item) => (
+            <button
+              key={item.id}
+              css={DropdownContent}
+              onClick={() => onItemSelect(item)}
+            >
+              <LocationIcon fill={color.GrayScale.gray4} />
+              <div css={DropdownText}>
+                <p css={DropdownTextName}>{item.name}</p>
+                <p css={DropdownTextAddr}>{item.addr}</p>
+              </div>
+            </button>
+          ))
+        ) : (
+          <div css={DropdownContent}>
+            <InfoIcon fill={color.GrayScale.gray4} />
+            <p css={NoContentText}>검색 결과가 없어요</p>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/features/addressInput/AddressInput.style.ts
+++ b/frontend/src/features/addressInput/AddressInput.style.ts
@@ -23,7 +23,7 @@ export const DropdownContainer = css`
   margin-top: 12px;
   background-color: ${color.GrayScale.white};
   width: 100%;
-  height: 446px;
+  max-height: 446px;
   border: 1px solid ${color.GrayScale.gray3};
   border-radius: ${borderRadius.Large};
   overflow: hidden;
@@ -46,6 +46,7 @@ export const HeaderStyle = css`
 export const DropdownContentList = css`
   display: flex;
   flex-direction: column;
+
   overflow-y: scroll;
 `;
 
@@ -90,4 +91,18 @@ export const CloseButtonStyle = css`
   display: flex;
   align-items: center;
   justify-content: center;
+`;
+
+export const NoContentText = css`
+  font: ${typography.Body.b3_medi};
+  color: ${color.GrayScale.gray4};
+`;
+
+export const LoadingContent = css`
+  display: flex;
+  gap: 12px;
+  border-bottom: 1px solid ${color.GrayScale.gray2};
+  align-items: center;
+  justify-content: center;
+  min-height: 80px;
 `;

--- a/frontend/src/features/addressInput/useAddressSearch.ts
+++ b/frontend/src/features/addressInput/useAddressSearch.ts
@@ -1,0 +1,86 @@
+import { useEffect, useState } from "react";
+import { fetchKakaoSearch } from "@/apis/KakaoSearchAPI";
+import type { AddressItem } from "./AddressDropdown";
+
+interface UseAddressSearchProps {
+  query: string;
+  enabled: boolean;
+}
+
+interface UseAddressSearchReturn {
+  results: AddressItem[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+// 노원구 상계동 기준 위치
+const DEFAULT_LOCATION = {
+  x: 127.06694995614, // 경도
+  y: 37.655038011447, // 위도
+};
+// 기준 위치에서 검색 허용 반경
+const DEFAULT_DISTANCE = 20 * 100; // 20km
+
+export const useAddressSearch = ({
+  query,
+  enabled,
+}: UseAddressSearchProps): UseAddressSearchReturn => {
+  const [results, setResults] = useState<AddressItem[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!enabled || !query.trim()) {
+      setResults([]);
+      setIsLoading(false);
+      setError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+
+    const searchAddress = async () => {
+      try {
+        setIsLoading(true);
+        setError(null);
+
+        const response = await fetchKakaoSearch({
+          query: query.trim(),
+          size: 10,
+          x: DEFAULT_LOCATION.x,
+          y: DEFAULT_LOCATION.y,
+          radius: DEFAULT_DISTANCE,
+          signal: controller.signal,
+          sort: "accuracy",
+        });
+
+        const transformedResults: AddressItem[] = response.documents.map(
+          (doc) => ({
+            id: doc.id,
+            name: doc.place_name,
+            addr: doc.road_address_name || doc.address_name,
+          }),
+        );
+
+        setResults(transformedResults);
+      } catch (err) {
+        if (err instanceof Error && err.name === "AbortError") {
+          return;
+        }
+
+        setError("주소 검색 중 오류가 발생했어요");
+        setResults([]);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    void searchAddress();
+
+    return () => {
+      controller.abort();
+    };
+  }, [query, enabled]);
+
+  return { results, isLoading, error };
+};

--- a/frontend/src/features/addressInput/useAddressSearch.ts
+++ b/frontend/src/features/addressInput/useAddressSearch.ts
@@ -19,7 +19,7 @@ const DEFAULT_LOCATION = {
   y: 37.655038011447, // 위도
 };
 // 기준 위치에서 검색 허용 반경
-const DEFAULT_DISTANCE = 20 * 100; // 20km
+const DEFAULT_DISTANCE = 20 * 1000; // 20km
 
 export const useAddressSearch = ({
   query,

--- a/frontend/src/features/refetchTimer/rotateAnimation.util.ts
+++ b/frontend/src/features/refetchTimer/rotateAnimation.util.ts
@@ -9,6 +9,6 @@ const rotate360 = keyframes`
   }
 `;
 
-export const rotating = css`
-  animation: ${rotate360} 1s linear;
+export const rotating = (isInfinite?: boolean) => css`
+  animation: ${rotate360} 1s linear ${isInfinite ? "infinite" : "1"};
 `;

--- a/frontend/src/hooks/useDebounce.ts
+++ b/frontend/src/hooks/useDebounce.ts
@@ -1,0 +1,14 @@
+import { useEffect, useState } from "react";
+
+export const useDebounce = <T>(value: T, delay: number = 300): T => {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+  return debouncedValue;
+};

--- a/frontend/src/types/kakaoSearch.types.ts
+++ b/frontend/src/types/kakaoSearch.types.ts
@@ -1,0 +1,33 @@
+// 카카오 장소 검색 API 응답 타입 정의
+export interface KakaoMeta {
+  total_count: number;
+  pageable_count: number;
+  is_end: boolean;
+}
+
+export interface KakaoPlace {
+  id: string;
+  place_name: string;
+  road_address_name: string;
+  address_name: string;
+  x: string; // 경도 lon
+  y: string; // 위도 lat
+  place_url: string;
+  distance?: string;
+}
+
+export interface KakaoKeywordResponse {
+  meta: KakaoMeta;
+  documents: KakaoPlace[];
+}
+
+/** UI에서 쓰는 공통 항목 (Dropdown용) */
+export interface AddressItem {
+  id: string;
+  name: string;
+  addr: string;
+  lat: number; // +y
+  lon: number; // +x
+  placeUrl?: string;
+  distance?: number;
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Close #282 

## 📝 기능 설명
- 예약자 등록 페이지 장소 입력 컴포넌트에 카카오 장소 검색 API를 연동했습니다.
- 범용적으로 사용할 수 있는 로딩스피너를 제작했습니다.

## 🛠 작업 사항
- KakaoSearchAPI에 fetch 함수를 만들어두고, useAdressSearch 훅에서 사용합니다.
- 해당 주소로의 API는 하나밖에 없기에 axios instance를 만들기엔 오버엔지니어링이라 판단되어 fetch함수로 만들었습니다.
- 훅 내부에서 서비스상 위치인 노원구 상계동 위도 / 경도를 설정하였으며 중심 위치 기준 20km 내부의 결과값만 받아오게 하였습니다.
- 디바운스 훅을 만들어서 입력된 값이 지정된 디바운싱 시간이 지날 때마다 API 요청을 보내게 하였습니다.
- js내부 AbortController를 사용하여 기존 요청의 응답이 오지 않은채 새로운 요청을 보냈을 때, 기존 요청을 취소하게 구현했습니다.

## ✅ 작업 항목
- [x] 디바운스 훅 생성
- [x] 드롭다운에 로딩 / 에러 처리 로직 추가
- [x] Kakao REST API Key 발급 및 연동
- [x] 경로 fetch 함수 생성
- [x] 로딩 스피너 추가

## 📎 참고 자료
- 장소 검색

https://github.com/user-attachments/assets/8869f125-19ca-45b7-8d72-5935d399b597


- 로딩 스피너 (3g로 인터넷 속도 제한)

https://github.com/user-attachments/assets/5a292074-a975-4e53-89df-62e23a36f8be

