### PR TITLE
[Feat/#299] 예약자 등록 폼 제출 / 유효성 검증 로직 추가

### DIFF
--- a/frontend/src/components/LoadingSpinner.tsx
+++ b/frontend/src/components/LoadingSpinner.tsx
@@ -1,6 +1,6 @@
 import { css } from "@emotion/react";
 import { theme } from "@/styles/themes.style";
-import { rotating } from "@/features/refetchTimer/rotateAnimation.util";
+import { rotating } from "@/utils/RotateAnimation";
 
 const { color } = theme;
 

--- a/frontend/src/features/addressInput/AddressInput.tsx
+++ b/frontend/src/features/addressInput/AddressInput.tsx
@@ -9,16 +9,30 @@ import { useAddressSearch } from "./useAddressSearch";
 
 const { color } = theme;
 
+interface AddressInputProps {
+  onFocus?: () => void;
+  onDepartureChange?: (address: string) => void;
+  onDestinationChange?: (address: string) => void;
+  departureValue?: string;
+  destinationValue?: string;
+}
+
 type Field = "departure" | "destination";
 type FieldState = { draft: string; value: AddressItem | null };
 
 const DEBOUNCE_DELAY = 300;
 
-const AddressInput = () => {
+const AddressInput = ({
+  onFocus,
+  onDepartureChange,
+  onDestinationChange,
+  departureValue = "",
+  destinationValue = "",
+}: AddressInputProps) => {
   const [focusedInput, setFocusedInput] = useState<Field | null>(null);
   const [fields, setFields] = useState<Record<Field, FieldState>>({
-    departure: { draft: "", value: null },
-    destination: { draft: "", value: null },
+    departure: { draft: departureValue, value: null },
+    destination: { draft: destinationValue, value: null },
   });
 
   // 현재 포커스된 입력의 draft 값 추출
@@ -32,6 +46,7 @@ const AddressInput = () => {
 
   const handleInputFocus = (type: Field) => {
     setFocusedInput(type);
+    onFocus?.(); // 외부 onFocus 콜백 호출
   };
 
   const handleDraftChange = (
@@ -52,6 +67,14 @@ const AddressInput = () => {
       ...prev,
       [focusedInput]: { draft: item.name, value: item },
     }));
+
+    // 선택된 주소의 addr 값을 외부로 전달
+    if (focusedInput === "departure" && onDepartureChange) {
+      onDepartureChange(item.addr);
+    } else if (focusedInput === "destination" && onDestinationChange) {
+      onDestinationChange(item.addr);
+    }
+
     setFocusedInput(null);
   };
 

--- a/frontend/src/features/calender/Calender.util.ts
+++ b/frontend/src/features/calender/Calender.util.ts
@@ -36,12 +36,14 @@ export const formatDateToYYMMDD = (date: Date): string => {
 /**
  * 주어진 시각을 "HH:mm" 형식의 문자열로 변환합니다.
  * @param {number} hour - 포맷팅 할 시각(9 ~ 23)
+ * @param {number} minute - 포맷팅 할 분(0 ~ 59) (없으면 00으로 적용)
  * @returns {string} - "HH:mm" 형식의 시간 문자열
  */
-export const formatTimeToHHMM = (hour: number): string => {
+export const formatTimeToHHMM = (hour: number, minute: number = 0): string => {
   const date = new Date();
   date.setHours(hour);
-  return format(date, "HH") + ":00";
+  date.setMinutes(minute);
+  return format(date, "HH:mm");
 };
 
 /**

--- a/frontend/src/features/userRegister/UserInputSection.tsx
+++ b/frontend/src/features/userRegister/UserInputSection.tsx
@@ -1,133 +1,313 @@
 import { css } from "@emotion/react";
+import { useState, useReducer, useRef } from "react";
+import { createPortal } from "react-dom";
+import { useForm, Controller } from "react-hook-form";
 import { theme } from "@/styles/themes.style";
 import Input from "@/components/Input";
+import Button from "@/components/Button";
+import RadioGroup from "@/components/RadioGroup";
 import { CalenderIcon, TimeIcon } from "@/assets/icons";
 import AddressInput from "@/features/addressInput/AddressInput";
-import RadioGroup from "@/components/RadioGroup";
-import { useState } from "react";
-import Button from "@/components/Button";
 import Calender from "@/features/calender/Calender";
 import TimePicker from "@/features/timePicker/TimePicker";
+import {
+  validateName,
+  validatePhone,
+  validateDate,
+  formatTimeDisplay,
+  formatPhone,
+} from "@/utils/UserValidation";
+import {
+  calenderReducer,
+  initialState,
+} from "@/features/calender/CalenderReducer";
+import { formatDateToYYMMDD } from "@/features/calender/Calender.util";
 
 const { color } = theme;
+
+interface UserFormData {
+  bookName: string;
+  bookTel: string;
+  hospitalDate: string;
+  hospitalTime: string;
+  startAddr: string;
+  endAddr: string;
+  walker: boolean;
+}
 
 type PopupType = "calendar" | "timePicker" | null;
 
 const UserInputSection = () => {
   const radioGroupItem = ["소유", "미소유"];
-  const [selectedState, setSelectedState] = useState("소유");
 
-  // 팝업 상태 관리
   const [activePopup, setActivePopup] = useState<PopupType>(null);
+  const [state, dispatch] = useReducer(calenderReducer, initialState);
 
-  // 임시 상태 (나중에 실제 값으로 교체)
-  const [calendarDate, setCalendarDate] = useState(new Date());
-  const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+  // Input 컨테이너 refs
+  const dateInputRef = useRef<HTMLDivElement>(null);
+  const timeInputRef = useRef<HTMLDivElement>(null);
 
-  // 팝업 핸들러
-  const handleCalendarClick = () => {
-    setActivePopup(activePopup === "calendar" ? null : "calendar");
+  const {
+    control,
+    handleSubmit,
+    setValue,
+    watch,
+    formState: { errors, isValid },
+    trigger,
+  } = useForm<UserFormData>({
+    mode: "onChange",
+    defaultValues: {
+      bookName: "",
+      bookTel: "",
+      hospitalDate: "",
+      hospitalTime: "",
+      startAddr: "",
+      endAddr: "",
+      walker: true,
+    },
+  });
+
+  // 폼 제출 핸들러
+  const onSubmit = (formData: UserFormData) => {
+    const formattedData = {
+      ...formData,
+      bookTel: formatPhone(formData.bookTel),
+    };
+
+    alert(`폼 제출: ${JSON.stringify(formattedData)}`);
   };
 
-  const handleTimePickerClick = () => {
-    setActivePopup(activePopup === "timePicker" ? null : "timePicker");
+  // 팝업 관련 핸들러들
+  const closePopup = () => setActivePopup(null);
+
+  // Portal을 위한 DOM 요소 찾기
+  const portalTarget = document.getElementById("admin-portal");
+
+  // Portal 팝업 렌더링 함수
+  const renderPopupPortal = () => {
+    if (!activePopup || !portalTarget) return null;
+
+    // 해당 Input의 위치 계산
+    const inputRef = activePopup === "calendar" ? dateInputRef : timeInputRef;
+    const inputElement = inputRef.current;
+
+    if (!inputElement) return null;
+
+    const rect = inputElement.getBoundingClientRect();
+    const popupRight = rect.right - rect.width;
+    const popupTop = rect.bottom + rect.height * 0.2;
+
+    const popupContent =
+      activePopup === "calendar" ? (
+        <Calender
+          highlightType="day"
+          calendarDate={state.calendarDate}
+          selectedDate={state.selectedDate}
+          onPrevMonth={() => handleMonthChange("prev")}
+          onNextMonth={() => handleMonthChange("next")}
+          onDateClick={handleDateClick}
+          isPopup={true}
+          onCancel={closePopup}
+          onConfirm={handleCalendarConfirm}
+        />
+      ) : (
+        <TimePicker onCancel={closePopup} onConfirm={handleTimeConfirm} />
+      );
+
+    return createPortal(
+      <div css={PortalOverlay} onClick={closePopup}>
+        <div
+          css={PortalContent}
+          onClick={(e) => e.stopPropagation()}
+          style={{
+            position: "absolute",
+            top: popupTop,
+            left: popupRight,
+          }}
+        >
+          {popupContent}
+        </div>
+      </div>,
+      portalTarget,
+    );
   };
 
-  const handleClosePopup = () => {
-    setActivePopup(null);
-  };
-
-  const handlePrevMonth = () => {
-    const prevMonth = new Date(calendarDate);
-    prevMonth.setMonth(prevMonth.getMonth() - 1);
-    setCalendarDate(prevMonth);
-  };
-
-  const handleNextMonth = () => {
-    const nextMonth = new Date(calendarDate);
-    nextMonth.setMonth(nextMonth.getMonth() + 1);
-    setCalendarDate(nextMonth);
+  // 캘린더 관련 핸들러들
+  const handleMonthChange = (direction: "next" | "prev") => {
+    dispatch({
+      type: "CHANGE_MONTH",
+      payload: state.calendarDate,
+      direction: direction,
+    });
   };
 
   const handleDateClick = (date: Date) => {
-    setSelectedDate(date);
-    // TODO 재민 - Input value 업데이트 로직 추가
+    dispatch({ type: "SELECT_DATE", payload: date });
   };
 
-  const handleCalendarConfirm = (_date: Date | null) => {
-    // TODO 재민 - Input value 업데이트 로직 추가
-    setActivePopup(null);
+  const handleCalendarConfirm = (date: Date | null) => {
+    if (date) {
+      const formattedDate = formatDateToYYMMDD(date);
+      setValue("hospitalDate", formattedDate);
+      void trigger("hospitalDate");
+    }
+    closePopup();
   };
 
-  const handleTimeConfirm = (_time: string) => {
-    // TODO 재민 - Input value 업데이트 로직 추가
-    setActivePopup(null);
+  // 시간 선택 핸들러
+  const handleTimeConfirm = (time: string) => {
+    setValue("hospitalTime", time);
+    void trigger("hospitalTime");
+    closePopup();
   };
+
+  // 보행기구 변경 핸들러
+  const handleWalkerChange = (value: string) => {
+    setValue("walker", value === "소유");
+  };
+
+  // 주소 변경 핸들러들
+  const handleDepartureChange = (address: string) => {
+    setValue("startAddr", address);
+    void trigger("startAddr");
+  };
+
+  const handleDestinationChange = (address: string) => {
+    setValue("endAddr", address);
+    void trigger("endAddr");
+  };
+
+  const startAddrValue = watch("startAddr") || "";
+  const endAddrValue = watch("endAddr") || "";
 
   return (
-    <div css={UserInputSectionContainer}>
-      <Input label="이름" required={true} placeholder="이름을 입력해주세요" />
-      <Input
-        label="전화번호"
-        required
-        placeholder="'-'를 제외하고 숫자만 입력해주세요"
-      />
+    <>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <div css={UserInputSectionContainer}>
+          {/* 이름 입력 */}
+          <Controller
+            name="bookName"
+            control={control}
+            rules={{
+              validate: (value) => validateName(value) || true,
+            }}
+            render={({ field }) => (
+              <Input
+                {...field}
+                label="이름"
+                required
+                placeholder="이름을 입력해주세요"
+                errorMessage={errors.bookName?.message}
+              />
+            )}
+          />
 
-      <div css={InputWithPopupContainer}>
-        <Input
-          label="예약날짜"
-          required
-          icon={<CalenderIcon fill={color.GrayScale.gray4} />}
-          placeholder="날짜를 선택해주세요"
-          readOnly
-          onClick={handleCalendarClick}
-        />
-        {activePopup === "calendar" && (
-          <div css={PopupContainer}>
-            <Calender
-              highlightType="day"
-              calendarDate={calendarDate}
-              selectedDate={selectedDate}
-              onPrevMonth={handlePrevMonth}
-              onNextMonth={handleNextMonth}
-              onDateClick={handleDateClick}
-              isPopup={true}
-              onCancel={handleClosePopup}
-              onConfirm={handleCalendarConfirm}
+          {/* 전화번호 입력 */}
+          <Controller
+            name="bookTel"
+            control={control}
+            rules={{
+              validate: (value) => validatePhone(value) || true,
+            }}
+            render={({ field }) => (
+              <Input
+                {...field}
+                label="전화번호"
+                required
+                placeholder="'-'를 제외하고 숫자만 입력해주세요"
+                errorMessage={errors.bookTel?.message}
+                onChange={(e) => {
+                  const value = e.target.value.replace(/\D/g, "");
+                  field.onChange(value);
+                }}
+              />
+            )}
+          />
+
+          {/* 예약날짜 입력 */}
+          <div ref={dateInputRef}>
+            <Controller
+              name="hospitalDate"
+              control={control}
+              rules={{
+                validate: (value) => validateDate(value) || true,
+              }}
+              render={({ field }) => (
+                <Input
+                  {...field}
+                  label="예약날짜"
+                  required
+                  icon={<CalenderIcon fill={color.GrayScale.gray4} />}
+                  placeholder="날짜를 선택해주세요"
+                  readOnly
+                  onFocus={() => setActivePopup("calendar")}
+                  errorMessage={errors.hospitalDate?.message}
+                  value={field.value || ""}
+                />
+              )}
             />
           </div>
-        )}
-      </div>
 
-      <AddressInput />
+          {/* 주소 입력 */}
+          <AddressInput
+            onDepartureChange={handleDepartureChange}
+            onDestinationChange={handleDestinationChange}
+            departureValue={startAddrValue}
+            destinationValue={endAddrValue}
+          />
 
-      <div css={InputWithPopupContainer}>
-        <Input
-          label="병원 도착 시간"
-          required
-          icon={<TimeIcon fill={color.GrayScale.gray4} />}
-          placeholder="병원 도착 시간을 입력해주세요"
-          readOnly
-          onClick={handleTimePickerClick}
-        />
-        {activePopup === "timePicker" && (
-          <div css={PopupContainer}>
-            <TimePicker
-              onCancel={handleClosePopup}
-              onConfirm={handleTimeConfirm}
+          {/* 도착 시간 입력 */}
+          <div ref={timeInputRef}>
+            <Controller
+              name="hospitalTime"
+              control={control}
+              rules={{
+                required: "병원 도착 시간을 선택해주세요",
+              }}
+              render={({ field }) => (
+                <Input
+                  {...field}
+                  label="병원 도착 시간"
+                  required
+                  icon={<TimeIcon fill={color.GrayScale.gray4} />}
+                  placeholder="병원 도착 시간을 입력해주세요"
+                  readOnly
+                  onFocus={() => setActivePopup("timePicker")}
+                  errorMessage={errors.hospitalTime?.message}
+                  value={field.value ? formatTimeDisplay(field.value) : ""}
+                />
+              )}
             />
           </div>
-        )}
-      </div>
 
-      <RadioGroup
-        label="보행 특이사항 (보행기구 유무)"
-        group={radioGroupItem}
-        selected={selectedState}
-        setSelected={setSelectedState}
-      />
-      <Button type="submit" bgColor="gray" label="등록하기" size="big" />
-    </div>
+          {/* 보행기구 유무 */}
+          <Controller
+            name="walker"
+            control={control}
+            render={({ field }) => (
+              <RadioGroup
+                label="보행 특이사항 (보행기구 유무)"
+                group={radioGroupItem}
+                selected={field.value ? "소유" : "미소유"}
+                setSelected={handleWalkerChange}
+              />
+            )}
+          />
+
+          {/* 제출 버튼 */}
+          <Button
+            type="submit"
+            bgColor={isValid ? "orange" : "gray"}
+            label="등록하기"
+            size="big"
+            disabled={!isValid}
+          />
+        </div>
+      </form>
+
+      {/* Portal로 렌더링되는 팝업 */}
+      {renderPopupPortal()}
+    </>
   );
 };
 
@@ -139,34 +319,35 @@ const UserInputSectionContainer = css`
   gap: 40px;
 `;
 
-const InputWithPopupContainer = css`
-  position: relative;
-  display: flex;
-  flex-direction: column;
+const PortalOverlay = css`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: transparent;
+  z-index: 1000;
 `;
 
-const PopupContainer = css`
-  position: absolute;
-  top: 100%;
-  right: 0;
-  margin-top: 12px;
-  z-index: 10;
+const PortalContent = css`
   background-color: ${color.GrayScale.white};
   border-radius: 12px;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.12);
+  max-width: 90vw;
+  max-height: 90vh;
+  overflow: auto;
 
   /* 애니메이션 효과 */
-  animation: popupSlideIn 0.3s cubic-bezier(0.16, 1, 0.3, 1);
-  transform-origin: top;
+  animation: contentSlideIn 0.3s cubic-bezier(0.16, 1, 0.3, 1);
 
-  @keyframes popupSlideIn {
-    0% {
+  @keyframes contentSlideIn {
+    from {
       opacity: 0;
-      transform: translateY(-8px) scale(0.95);
+      transform: scale(0.95) translateY(-8px);
     }
-    100% {
+    to {
       opacity: 1;
-      transform: translateY(0) scale(1);
+      transform: scale(1) translateY(0);
     }
   }
 `;

--- a/frontend/src/features/userRegister/UserRegister.types.ts
+++ b/frontend/src/features/userRegister/UserRegister.types.ts
@@ -1,0 +1,19 @@
+export interface UserFormData {
+  bookName: string;
+  bookTel: string;
+  hospitalDate: string;
+  hospitalTime: string;
+  startAddr: string;
+  endAddr: string;
+  walker: boolean;
+}
+
+export type PopupType = "calendar" | "timePicker" | null;
+
+export interface FormFieldProps {
+  label: string;
+  placeholder: string;
+  required?: boolean;
+  icon?: React.ReactNode;
+  errorMessage?: string;
+}

--- a/frontend/src/layouts/AdminLayout.tsx
+++ b/frontend/src/layouts/AdminLayout.tsx
@@ -8,6 +8,7 @@ const AdminLayout = () => {
       <div css={ContentContainer}>
         <Outlet />
       </div>
+      <div id="admin-portal" />
     </div>
   );
 };

--- a/frontend/src/utils/UserValidation.ts
+++ b/frontend/src/utils/UserValidation.ts
@@ -79,20 +79,6 @@ export const formatPhone = (value: string): string => {
   return `${numbers.slice(0, 3)}-${numbers.slice(3, 7)}-${numbers.slice(7, 11)}`;
 };
 
-export const formatTime = (
-  hour: string,
-  minute: string,
-  meridiem: string,
-): string => {
-  let h = parseInt(hour);
-  const m = parseInt(minute);
-
-  if (meridiem === "PM") h += 12;
-  if (meridiem === "AM") h = 0;
-
-  return formatTimeToHHMM(h, m);
-};
-
 export const formatTime24Hour = (
   hour: string,
   minute: string,

--- a/frontend/src/utils/UserValidation.ts
+++ b/frontend/src/utils/UserValidation.ts
@@ -1,0 +1,124 @@
+import { formatTimeToHHMM } from "@/features/calender/Calender.util";
+
+export const validateName = (value: string): string | null => {
+  if (!value) return "이름을 입력해주세요";
+  if (value.length < 2 || value.length > 10)
+    return "이름은 2-10자 사이로 입력해주세요";
+  if (!/^[가-힣]+$/.test(value)) return "한글만 입력 가능합니다";
+  return null;
+};
+
+export const validatePhone = (value: string): string | null => {
+  if (!value) return "전화번호를 입력해주세요";
+  const numbers = value.replace(/\D/g, "");
+  if (numbers.length !== 11) return "11자리 숫자를 입력해주세요";
+  return null;
+};
+
+export const validateDate = (value: string): string | null => {
+  if (!value) return "예약 날짜를 선택해주세요";
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const selectedDate = new Date(value);
+  if (selectedDate < today) return "오늘 이후 날짜를 선택해주세요";
+  return null;
+};
+
+export const validateTime = (hour: string, minute: string): string | null => {
+  if (!hour || !minute) return "시간을 입력해주세요";
+  const h = parseInt(hour);
+  const m = parseInt(minute);
+  if (h < 1 || h > 12) return "시간은 1-12 사이로 입력해주세요";
+  if (m < 0 || m > 59) return "분은 0-59 사이로 입력해주세요";
+  return null;
+};
+
+// TimePicker 전용 유효성 검사 함수들
+export const validateHour = (hour: string): string | null => {
+  if (!hour && hour !== "0") return "시간을 입력해주세요";
+  const h = parseInt(hour);
+  if (isNaN(h)) return "숫자를 입력해주세요";
+  if (h < 0 || h > 12) return "시간은 0-12 사이로 입력해주세요";
+  return null;
+};
+
+export const validateMinute = (minute: string): string | null => {
+  if (!minute && minute !== "0") return "분을 입력해주세요";
+  const m = parseInt(minute);
+  if (isNaN(m)) return "숫자를 입력해주세요";
+  if (m < 0 || m > 59) return "분은 0-59 사이로 입력해주세요";
+  return null;
+};
+
+export const validateTimePicker = (
+  hour: string,
+  minute: string,
+): string | null => {
+  const hourError = validateHour(hour);
+  if (hourError) return hourError;
+
+  const minuteError = validateMinute(minute);
+  if (minuteError) return minuteError;
+
+  return null;
+};
+
+export const validateAddress = (
+  departure: string,
+  destination: string,
+): string | null => {
+  if (!departure) return "출발지를 선택해주세요";
+  if (!destination) return "도착지를 선택해주세요";
+  if (departure === destination) return "출발지와 도착지가 같을 수 없습니다";
+  return null;
+};
+
+// 포맷팅 유틸리티
+export const formatPhone = (value: string): string => {
+  const numbers = value.replace(/\D/g, "");
+  return `${numbers.slice(0, 3)}-${numbers.slice(3, 7)}-${numbers.slice(7, 11)}`;
+};
+
+export const formatTime = (
+  hour: string,
+  minute: string,
+  meridiem: string,
+): string => {
+  let h = parseInt(hour);
+  const m = parseInt(minute);
+
+  if (meridiem === "PM") h += 12;
+  if (meridiem === "AM") h = 0;
+
+  return formatTimeToHHMM(h, m);
+};
+
+export const formatTime24Hour = (
+  hour: string,
+  minute: string,
+  meridiem: string,
+): string => {
+  let h = parseInt(hour);
+  const m = parseInt(minute);
+
+  // 12시간 형식을 24시간 형식으로 변환
+  if (meridiem === "AM") {
+    h = h === 12 ? 0 : h; // 12 AM = 0시
+  } else {
+    h = h === 12 ? 12 : h + 12; // 12 PM = 12시, 나머지는 +12
+  }
+
+  return formatTimeToHHMM(h, m);
+};
+
+export const formatTimeDisplay = (time24: string): string => {
+  if (!time24) return "";
+
+  const [hourStr, minuteStr] = time24.split(":");
+  const hour = parseInt(hourStr);
+
+  const meridiem = hour < 12 ? "AM" : "PM";
+  const displayHour = hour === 0 ? 12 : hour > 12 ? hour - 12 : hour;
+
+  return `${displayHour}:${minuteStr} ${meridiem}`;
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Close #299 

## 📝 기능 설명
예약자 관리 페이지(`/admin/book/register`)의 폼 관리 로직 + 유효성 검증 로직을 추가했습니다.

## 🛠 작업 사항
### 유효성 검사 로직
- 이름, 전화번호, 시간데이터, 날짜데이터의 로직을 함수로 직접 구현했습니다.
- 팝업은 페이지 내부에서 하나만 열려야해서, 열림 상태를 하나로 두어 관리했습니다.
- 팝업이 focus를 잃거나, 다른 부분이 클릭될 때 닫혀야하는데 해당 기능 구현이 어려워 고민을 했습니다.
- react-portal을 통해 전체 레이아웃에 보이지않는 컨테이너를 두고, 그 위에 절대위치로 팝업을 올려두었습니다.
-> 결과: 팝업 이외의 어느 곳을 클릭하든 팝업이 닫힙니다.
- 위치 값은 "장소명" + "도로명 주소" 로 구성되는데, 사용자에게 보이는 내용은 "장소명" 이지만 실제 폼 제출 시에는 "도로명 주소"가 제출됩니다.

## ✅ 작업 항목
- [x] 이름 유효성 검사
- [x] 전화번호 유효성 검사
- [x] 날짜 유효성 검사
- [x] 출발지 / 도착지 유효성 검사
- [x] 도착 예정 시간 유효성 검사
- [x] 활성화된 팝업 하나로 관리
- [x] 만들어진 폼을 백엔드 API 형태로 파싱하는 함수 제작

## 📎 참고 자료

https://github.com/user-attachments/assets/e41a04d3-af5f-47ba-9f1c-cc6d42384bd9

