### PR TITLE
[Feat/#302] 확정된 경로의 좌표를 데이터베이스에 반영

### DIFF
--- a/backend/src/main/java/hyfive/gachita/application/node/Node.java
+++ b/backend/src/main/java/hyfive/gachita/application/node/Node.java
@@ -47,7 +47,7 @@ public class Node {
     @Column(name = "type", nullable = false, columnDefinition = "VARCHAR(50)")
     private NodeType type;
 
-    @OneToOne(mappedBy = "endNode")
+    @OneToOne(mappedBy = "endNode", cascade = CascadeType.ALL)
     private Segment leftSegment;
 }
 

--- a/backend/src/main/java/hyfive/gachita/application/node/Point.java
+++ b/backend/src/main/java/hyfive/gachita/application/node/Point.java
@@ -2,6 +2,7 @@ package hyfive.gachita.application.node;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,6 +11,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Entity
 @Table(name = "point")
+@Builder
 public class Point {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/hyfive/gachita/application/node/Segment.java
+++ b/backend/src/main/java/hyfive/gachita/application/node/Segment.java
@@ -3,6 +3,7 @@ package hyfive.gachita.application.node;
 import hyfive.gachita.client.geocode.dto.LatLng;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -14,6 +15,7 @@ import java.util.List;
 @AllArgsConstructor
 @Entity
 @Table(name = "segment")
+@Builder
 public class Segment {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,16 +39,7 @@ public class Segment {
     @OneToMany(mappedBy = "segment", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Point> points = new ArrayList<>();
 
-    public void setPolyline(List<LatLng> polyline) {
-        points.clear();
-        for (LatLng location : polyline) {
-            points.add(
-                    Point.builder()
-                            .segment(this)
-                            .lat(location.lat())
-                            .lng(location.lng())
-                            .build()
-            );
-        }
+    public void setPoints(List<Point> points) {
+        this.points = points;
     }
 }

--- a/backend/src/main/java/hyfive/gachita/application/node/Segment.java
+++ b/backend/src/main/java/hyfive/gachita/application/node/Segment.java
@@ -1,5 +1,6 @@
 package hyfive.gachita.application.node;
 
+import hyfive.gachita.client.geocode.dto.LatLng;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -35,4 +36,17 @@ public class Segment {
 
     @OneToMany(mappedBy = "segment", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Point> points = new ArrayList<>();
+
+    public void setPolyline(List<LatLng> polyline) {
+        points.clear();
+        for (LatLng location : polyline) {
+            points.add(
+                    Point.builder()
+                            .segment(this)
+                            .lat(location.lat())
+                            .lng(location.lng())
+                            .build()
+            );
+        }
+    }
 }

--- a/backend/src/main/java/hyfive/gachita/application/path/PathService.java
+++ b/backend/src/main/java/hyfive/gachita/application/path/PathService.java
@@ -1,6 +1,7 @@
 package hyfive.gachita.application.path;
 
 import hyfive.gachita.application.book.Book;
+import hyfive.gachita.application.book.BookStatus;
 import hyfive.gachita.application.common.dto.PagedListRes;
 import hyfive.gachita.application.common.dto.ScrollRes;
 import hyfive.gachita.application.common.enums.SearchPeriod;
@@ -244,6 +245,7 @@ public class PathService {
 
             segment.setPoints(points);
             node.setLeftSegment(segment);
+            node.getBook().update(BookStatus.FIXED);
         }
     }
 

--- a/backend/src/main/java/hyfive/gachita/application/path/PathService.java
+++ b/backend/src/main/java/hyfive/gachita/application/path/PathService.java
@@ -240,6 +240,15 @@ public class PathService {
         }
     }
 
+    public void saveTodayPathPolyline() {
+        LocalDate today = LocalDate.now();
+        List<Path> pathList = pathRepository.findAllByDriveDate(today);
+
+        for (Path path : pathList) {
+            savePolyline(path.getId());
+        }
+    }
+
     private LocalTime minTime(LocalTime timeA, LocalTime timeB) {
         return timeA.isBefore(timeB) ? timeA : timeB;
     }

--- a/backend/src/main/java/hyfive/gachita/application/path/dto/HighlightRes.java
+++ b/backend/src/main/java/hyfive/gachita/application/path/dto/HighlightRes.java
@@ -19,8 +19,9 @@ public record HighlightRes(
         @Schema(description = "예약자 이름 또는 센터 이름", example = "김코드")
         String bookName,
 
-        @Schema(description = "보행기 사용 여부", example = "true")
-        boolean walker,
+        @Schema(description = "예약 시간(병원 도착 희망 시간)", example = "11:00")
+        @JsonFormat(pattern = "HH:mm")
+        LocalTime hospitalTime,
 
         @Schema(description = "승차 시간 (HH:mm)", example = "10:00")
         @JsonFormat(pattern = "HH:mm")
@@ -49,7 +50,7 @@ public record HighlightRes(
         return new HighlightRes(
                 book.getId(),
                 book.getBookName(),
-                book.getWalker(),
+                book.getHospitalTime(),
                 startNode.getTime(),
                 endNode.getTime(),
                 book.getStartAddr(),

--- a/backend/src/main/java/hyfive/gachita/application/path/respository/CustomPathRepository.java
+++ b/backend/src/main/java/hyfive/gachita/application/path/respository/CustomPathRepository.java
@@ -22,4 +22,6 @@ public interface CustomPathRepository {
                                          DriveStatus status,
                                          Pageable pageable);
     Optional<List<Node>> findNodeListWithSegmentInfoByPathId(Long id);
+
+    List<Node> findNodeListByPathId(Long id);
 }

--- a/backend/src/main/java/hyfive/gachita/application/path/respository/CustomPathRepository.java
+++ b/backend/src/main/java/hyfive/gachita/application/path/respository/CustomPathRepository.java
@@ -24,4 +24,6 @@ public interface CustomPathRepository {
     Optional<List<Node>> findNodeListWithSegmentInfoByPathId(Long id);
 
     List<Node> findNodeListByPathId(Long id);
+
+    List<Path> findAllByDriveDate(LocalDate today);
 }

--- a/backend/src/main/java/hyfive/gachita/application/path/respository/CustomPathRepositoryImpl.java
+++ b/backend/src/main/java/hyfive/gachita/application/path/respository/CustomPathRepositoryImpl.java
@@ -162,6 +162,16 @@ public class CustomPathRepositoryImpl implements CustomPathRepository {
                 .fetch());
     }
 
+    @Override
+    public List<Node> findNodeListByPathId(Long id) {
+        return queryFactory
+                .selectFrom(node)
+                .leftJoin(node.path, path)
+                .where(node.path.id.eq(id))
+                .orderBy(node.time.asc())
+                .fetch();
+    }
+
     private BooleanExpression statusEq(QPath path, DriveStatus status) {
         return status != null ? path.driveStatus.eq(status) : null;
     }

--- a/backend/src/main/java/hyfive/gachita/application/path/respository/CustomPathRepositoryImpl.java
+++ b/backend/src/main/java/hyfive/gachita/application/path/respository/CustomPathRepositoryImpl.java
@@ -166,9 +166,21 @@ public class CustomPathRepositoryImpl implements CustomPathRepository {
     public List<Node> findNodeListByPathId(Long id) {
         return queryFactory
                 .selectFrom(node)
-                .leftJoin(node.path, path)
+                .leftJoin(node.leftSegment, segment).fetchJoin()
                 .where(node.path.id.eq(id))
                 .orderBy(node.time.asc())
+                .fetch();
+    }
+
+    @Override
+    public List<Path> findAllByDriveDate(LocalDate today) {
+        return queryFactory
+                .selectFrom(path)
+                .where(
+                        path.driveDate.eq(today),
+                        path.driveStatus.eq(DriveStatus.WAITING)
+                )
+                .orderBy(path.realStartTime.asc(), path.realEndTime.asc(), path.id.desc())
                 .fetch();
     }
 

--- a/backend/src/main/java/hyfive/gachita/client/kakao/KakaoNaviService.java
+++ b/backend/src/main/java/hyfive/gachita/client/kakao/KakaoNaviService.java
@@ -49,7 +49,7 @@ public class KakaoNaviService {
         for (KakaoNaviRes.Road road : section.roads()) {
             List<Double> vertexes = road.vertexes();
             for (int i = 0; i < vertexes.size(); i += 2) {
-                pointList.add(new LatLng(vertexes.get(i), vertexes.get(i + 1)));
+                pointList.add(new LatLng(vertexes.get(i + 1), vertexes.get(i)));
             }
         }
         return pointList;

--- a/backend/src/main/java/hyfive/gachita/demo/DemoController.java
+++ b/backend/src/main/java/hyfive/gachita/demo/DemoController.java
@@ -18,4 +18,10 @@ public class DemoController {
         pathService.savePolyline(pathId);
         return BaseResponse.success("Polyline saved successfully");
     }
+
+    @RequestMapping("/path/today/save-polyline")
+    public BaseResponse<String> savePathPolyLine() {
+        pathService.saveTodayPathPolyline();
+        return BaseResponse.success("Polyline saved successfully");
+    }
 }

--- a/backend/src/main/java/hyfive/gachita/demo/DemoController.java
+++ b/backend/src/main/java/hyfive/gachita/demo/DemoController.java
@@ -2,7 +2,9 @@ package hyfive.gachita.demo;
 
 import hyfive.gachita.application.path.PathService;
 import hyfive.gachita.global.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -15,13 +17,21 @@ import java.util.Map;
 public class DemoController {
     private final PathService pathService;
 
-    @RequestMapping("/path/{pathId}/save-polyline")
+    @GetMapping("/path/{pathId}/save-polyline")
+    @Operation(
+            summary = "특정 Path의 Polyline 저장",
+            description = "pathId를 받아 해당 경로의 polyline 정보를 DB에 저장합니다."
+    )
     public BaseResponse<String> savePathPolyLine(@PathVariable Long pathId) {
         pathService.savePolyline(pathId);
         return BaseResponse.success("Polyline saved successfully");
     }
 
-    @RequestMapping("/path/today/save-polyline")
+    @GetMapping("/path/today/save-polyline")
+    @Operation(
+            summary = "운행 날짜가 오늘인 Path Polyline 저장",
+            description = "운행 날짜가 오늘인 모든 Path의 polyline 정보를 DB에 저장하고 결과를 반환합니다."
+    )
     public BaseResponse<Map<String, Object>> savePathPolyLine() {
         return BaseResponse.success(pathService.saveTodayPathPolyline());
     }

--- a/backend/src/main/java/hyfive/gachita/demo/DemoController.java
+++ b/backend/src/main/java/hyfive/gachita/demo/DemoController.java
@@ -1,0 +1,21 @@
+package hyfive.gachita.demo;
+
+import hyfive.gachita.application.path.PathService;
+import hyfive.gachita.global.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/demo")
+@RequiredArgsConstructor
+public class DemoController {
+    private final PathService pathService;
+
+    @RequestMapping("/path/{pathId}/save-polyline")
+    public BaseResponse<String> savePathPolyLine(@PathVariable Long pathId) {
+        pathService.savePolyline(pathId);
+        return BaseResponse.success("Polyline saved successfully");
+    }
+}

--- a/backend/src/main/java/hyfive/gachita/demo/DemoController.java
+++ b/backend/src/main/java/hyfive/gachita/demo/DemoController.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Map;
+
 @RestController
 @RequestMapping("/demo")
 @RequiredArgsConstructor
@@ -20,8 +22,7 @@ public class DemoController {
     }
 
     @RequestMapping("/path/today/save-polyline")
-    public BaseResponse<String> savePathPolyLine() {
-        pathService.saveTodayPathPolyline();
-        return BaseResponse.success("Polyline saved successfully");
+    public BaseResponse<Map<String, Object>> savePathPolyLine() {
+        return BaseResponse.success(pathService.saveTodayPathPolyline());
     }
 }

--- a/backend/src/main/java/hyfive/gachita/dispatch/dto/FilteredPathDto.java
+++ b/backend/src/main/java/hyfive/gachita/dispatch/dto/FilteredPathDto.java
@@ -6,23 +6,23 @@ import lombok.Builder;
 @Builder
 public record FilteredPathDto(
         Long pathId,
-        double lat,
-        double lng
+        double latt,
+        double lngg
 ) implements FilterDto {
 
     public static FilteredPathDto fromStart(Book book) {
         return FilteredPathDto.builder()
                 .pathId(book.getPath().getId())
-                .lat(book.getStartLat())
-                .lng(book.getStartLng())
+                .latt(book.getStartLat())
+                .lngg(book.getStartLng())
                 .build();
     }
 
     public static FilteredPathDto fromEnd(Book book) {
         return FilteredPathDto.builder()
                 .pathId(book.getPath().getId())
-                .lat(book.getEndLat())
-                .lng(book.getEndLng())
+                .latt(book.getEndLat())
+                .lngg(book.getEndLng())
                 .build();
     }
 

--- a/backend/src/main/java/hyfive/gachita/global/GlobalExceptionHandler.java
+++ b/backend/src/main/java/hyfive/gachita/global/GlobalExceptionHandler.java
@@ -44,7 +44,7 @@ public class GlobalExceptionHandler {
             log.error("{}", e.getMessage());
             return ResponseEntity
                     .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(BaseResponse.fail(ErrorCode.INTERNAL_SERVER_ERROR));
+                    .body(BaseResponse.fail(ErrorCode.INTERNAL_SERVER_ERROR, e.getMessage()));
         }
         log.info("{}", e.getMessage());
         return ResponseEntity


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Close #302 

## 📝 기능 설명
확정된 경로의 좌표를 데이터베이스에 반영
스케쥴러는 아직 도입하지 않았고, demo API를 만들어 호출할 수 있도록 하였습니다.
- 특정 경로 ID의 좌표를 저장 `/demo/path/{pathId}/save-polyline`
- 오늘 날짜의 운행 예정 경로 ID 좌표를 저장 `/path/today/save-polyline`

## 🛠 작업 사항
Segment, Point 테이블에 해당하는 데이터를 저장

**관련 오류 수정**
- FilterDto 무한 참조 임시 수정
- 카카오 API의 x, y좌표 위치 변경

**예약 정보 추가 전달**
예약자의 도착 희망시간에 해당하는 hospitalTime 전달

## ✅ 작업 항목
- [x] 구현
- [x] 응답 확인(프론트에게 해당 데이터 전달 후 지도 확인)

## 📎 참고 자료
<!-- 관련 문서, 링크, 스크린샷 등을 첨부해주세요 -->