### PR TITLE
feat : 운행 경로 관리 리스트 api에 경로 id로 검색할 수 있는 param 추가

### DIFF
--- a/backend/src/main/java/hyfive/gachita/application/path/PathController.java
+++ b/backend/src/main/java/hyfive/gachita/application/path/PathController.java
@@ -46,10 +46,11 @@ public class PathController implements PathDocs {
     public BaseResponse<PagedListRes<PathDetailRes>> getPathList(
             @RequestParam(name = "period", required = false, defaultValue = "TODAY") SearchPeriod period,
             @RequestParam(name = "status", required = false) DriveStatus status,
+            @RequestParam(name = "path-id", required = false) Long pathId,
             @RequestParam(name = "page", required = false, defaultValue = "1") int page,
             @RequestParam(name = "limit", required = false, defaultValue = "12") int limit
     ) {
-        return BaseResponse.success(pathService.getPathList(period, status, page, limit));
+        return BaseResponse.success(pathService.getPathList(period, status, pathId, page, limit));
     }
 
     @GetMapping("/{id}/nodes")

--- a/backend/src/main/java/hyfive/gachita/application/path/PathService.java
+++ b/backend/src/main/java/hyfive/gachita/application/path/PathService.java
@@ -147,14 +147,14 @@ public class PathService {
                 .build();
     }
 
-    public PagedListRes<PathDetailRes> getPathList(SearchPeriod period, DriveStatus status, int page, int limit) {
+    public PagedListRes<PathDetailRes> getPathList(SearchPeriod period, DriveStatus status, Long pathId, int page, int limit) {
         Pageable pageable = PageRequest.of(
                 page - 1,
                 limit
         );
 
         Pair<LocalDate, LocalDate> dateRange = DateRangeUtil.getDateRange(LocalDate.now(), period);
-        Page<Path> pageResult = pathRepository.searchPathPageByCondition(dateRange, status, pageable);
+        Page<Path> pageResult = pathRepository.searchPathPageByCondition(dateRange, status, pathId, pageable);
         List<PathDetailRes> pathResList = pageResult.getContent().stream().map(PathDetailRes::from).toList();
         return PagedListRes.<PathDetailRes>builder()
                 .items(pathResList)

--- a/backend/src/main/java/hyfive/gachita/application/path/respository/CustomPathRepository.java
+++ b/backend/src/main/java/hyfive/gachita/application/path/respository/CustomPathRepository.java
@@ -20,6 +20,7 @@ public interface CustomPathRepository {
     List<Path> findPathsForScroll(LocalDate date, DriveStatus status, PathCursor cursor, int size);
     Page<Path> searchPathPageByCondition(Pair<LocalDate, LocalDate> dateRange,
                                          DriveStatus status,
+                                         Long PathId,
                                          Pageable pageable);
     Optional<List<Node>> findNodeListWithSegmentInfoByPathId(Long id);
 

--- a/backend/src/main/java/hyfive/gachita/application/path/respository/CustomPathRepositoryImpl.java
+++ b/backend/src/main/java/hyfive/gachita/application/path/respository/CustomPathRepositoryImpl.java
@@ -137,13 +137,15 @@ public class CustomPathRepositoryImpl implements CustomPathRepository {
     @Override
     public Page<Path> searchPathPageByCondition(Pair<LocalDate, LocalDate> dateRange,
                                                 DriveStatus status,
+                                                Long pathId,
                                                 Pageable pageable) {
         List<Path> pathList = queryFactory
                 .select(path)
                 .from(path)
                 .where(
                         path.driveDate.between(dateRange.getFirst(), dateRange.getSecond()),
-                        statusEq(path, status)
+                        statusEq(path, status),
+                        pathId != null ? path.id.eq(pathId) : null
                 )
                 .orderBy(
                     path.realStartTime.asc(),
@@ -159,7 +161,8 @@ public class CustomPathRepositoryImpl implements CustomPathRepository {
                 .from(path)
                 .where(
                         path.driveDate.between(dateRange.getFirst(), dateRange.getSecond()),
-                        statusEq(path, status)
+                        statusEq(path, status),
+                        pathId != null ? path.id.eq(pathId) : null
                 )
                 .fetchOne();
 

--- a/backend/src/main/java/hyfive/gachita/docs/PathDocs.java
+++ b/backend/src/main/java/hyfive/gachita/docs/PathDocs.java
@@ -116,6 +116,13 @@ public interface PathDocs {
             @RequestParam(name = "status", required = false) DriveStatus status,
 
             @Parameter(
+                    name = "path-id",
+                    description = "경로 ID / null 값으로 요청하면 전체 경로를 조회",
+                    example = "1"
+            )
+            @RequestParam(name = "path-id",  required = false) Long pathId,
+
+            @Parameter(
                     name = "page",
                     description = "페이지 번호 (기본값: 1)",
                     example = "1"


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Close #331 

## 📝 기능 설명

운행 경로 관리 리스트 api에 경로 id로 검색할 수 있는 param을 추가했습니다.

## 🛠 작업 사항

### 1. PathController에 RequestParam 추가 (path-id)
- null을 입력할 경우 전체 경로를 조회합니다.
- path-id를 입력할 경우 입력한 경로만 조회합니다.

## ✅ 작업 항목
- [x] Docs 수정
- [x] PathController에 RequestParam 추가 (path-id)
- [x] CustomPathRepositoryImpl.searchPathPageByCondition 에 where 조건 추가

## 📎 참고 자료
