### PR TITLE
[Feat/#340] 예약자 관리 페이지에서 pathId로 운행 경로 페이지 라우팅

### DIFF
--- a/frontend/src/apis/RouteListAPI.ts
+++ b/frontend/src/apis/RouteListAPI.ts
@@ -22,14 +22,22 @@ export const useGetRouteList = (
   status: RouteFilterValue | "",
   page: number,
   limit: number,
+  pathId: number | null = null,
 ) => {
   if (status === "ALL") status = "";
-  const { data, error, isFetching } = useQuery<RouteListAPIResponse>({
-    queryKey: ["routeList", period, status, page, limit],
-    queryFn: () =>
-      clientInstance.get(
-        `/path/list?period=${period}&status=${status}&path-id=1&page=${page}&limit=${limit}`,
-      ),
+  const { data, error, isFetching, refetch } = useQuery<RouteListAPIResponse>({
+    queryKey: ["routeList", period, status, pathId, page, limit],
+    queryFn: () => {
+      const params = new URLSearchParams();
+      params.append("period", period);
+      params.append("status", status);
+      params.append("page", String(page));
+      params.append("limit", String(limit));
+      if (pathId !== null && pathId !== undefined) {
+        params.append("path-id", String(pathId));
+      }
+      return clientInstance.get(`/path/list?${params.toString()}`);
+    },
     throwOnError: true,
   });
   const routeList = data?.data.items.map((partData) =>
@@ -42,8 +50,8 @@ export const useGetRouteList = (
       totalPages: data?.data.totalPageNum ?? 1,
       totalItems: data?.data.totalItemNum ?? 0,
     },
-
     error,
     isFetching,
+    refetch,
   };
 };

--- a/frontend/src/components/table/TableWithIndex.tsx
+++ b/frontend/src/components/table/TableWithIndex.tsx
@@ -5,6 +5,7 @@ import {
   type RouteFilterValue,
   type UserFilterValue,
 } from "@/features/statusFilter/StatusFilter.constants";
+import type { DateFilterValue } from "@/features/dateFilter/DateFilter.constants";
 import { theme } from "@/styles/themes.style";
 import type { TableObject } from "@/utils/TableMatcher";
 import TableMatcher from "@/utils/TableMatcher";
@@ -14,6 +15,7 @@ const { color } = theme;
 
 interface TableProps {
   rows: TableObject[];
+  selectedDateFilter?: DateFilterValue;
 }
 
 const isUserFilterValue = (
@@ -28,12 +30,20 @@ const isRouteFilterValue = (
   return value in ROUTE_STATUS_META;
 };
 
-const TableWithIndex = ({ rows }: TableProps) => {
+const TableWithIndex = ({ rows, selectedDateFilter }: TableProps) => {
   const navigate = useNavigate();
   const { keys, labels } = TableMatcher.matchTableHeader(rows);
 
   const handleRouteIdClick = (routeId: string | number) => {
-    void navigate(`/admin/book/paths?routeId=${routeId}`);
+    const searchParams = new URLSearchParams();
+    searchParams.append("routeId", String(routeId));
+
+    // 선택된 날짜 필터가 있으면 URL 파라미터에 추가
+    if (selectedDateFilter) {
+      searchParams.append("period", selectedDateFilter);
+    }
+
+    void navigate(`/admin/book/paths?${searchParams.toString()}`);
   };
 
   const formatElement = ({

--- a/frontend/src/components/table/TableWithIndex.tsx
+++ b/frontend/src/components/table/TableWithIndex.tsx
@@ -9,6 +9,7 @@ import { theme } from "@/styles/themes.style";
 import type { TableObject } from "@/utils/TableMatcher";
 import TableMatcher from "@/utils/TableMatcher";
 import { css } from "@emotion/react";
+import { useNavigate } from "react-router";
 const { color } = theme;
 
 interface TableProps {
@@ -28,7 +29,13 @@ const isRouteFilterValue = (
 };
 
 const TableWithIndex = ({ rows }: TableProps) => {
+  const navigate = useNavigate();
   const { keys, labels } = TableMatcher.matchTableHeader(rows);
+
+  const handleRouteIdClick = (routeId: string | number) => {
+    void navigate(`/admin/book/paths?routeId=${routeId}`);
+  };
+
   const formatElement = ({
     key,
     value,
@@ -40,7 +47,13 @@ const TableWithIndex = ({ rows }: TableProps) => {
       case "isExistWalkingDevice":
         return value === true ? "o" : "-";
       case "routeId":
-        return value ? <p css={RouteIDStyle}>#{value}</p> : "-";
+        return value && typeof value !== "boolean" ? (
+          <p css={RouteIDStyle} onClick={() => handleRouteIdClick(value)}>
+            #{value}
+          </p>
+        ) : (
+          "-"
+        );
       case "totalUserCount":
         return value + "명";
       case "status": {

--- a/frontend/src/pages/admin/book/PathsPage.tsx
+++ b/frontend/src/pages/admin/book/PathsPage.tsx
@@ -36,14 +36,19 @@ const TOOLTIP_DATA = {
 const PathsPage = () => {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
-  const [selectedDateFilter, setSelectedDateFilter] =
-    useState<DateFilterValue>("TODAY");
+
+  // URL에서 파라미터 가져오기
+  const routeId = searchParams.get("routeId");
+  const periodFromUrl = searchParams.get("period") as DateFilterValue;
+
+  const [selectedDateFilter, setSelectedDateFilter] = useState<DateFilterValue>(
+    periodFromUrl || "TODAY",
+  );
   const [selectedStatusFilter, setSelectedStatusFilter] =
     useState<RouteFilterValue>("ALL");
   const [selectedPage, setSelectedPage] = useState(1);
   const ITEMS_PER_PAGE = 12;
 
-  const routeId = searchParams.get("routeId");
   const pathId = routeId ? Number(routeId) : null;
 
   const { items, pageInfo, isFetching } = useGetRouteList(

--- a/frontend/src/pages/admin/book/PathsPage.tsx
+++ b/frontend/src/pages/admin/book/PathsPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useSearchParams, useNavigate } from "react-router";
 
 // 타입
 import type { DateFilterValue } from "@/features/dateFilter/DateFilter.constants";
@@ -21,6 +22,7 @@ import { ROUTE_STATUS_FILTER_OPTIONS } from "@/features/statusFilter/StatusFilte
 import { useGetRouteList } from "@/apis/RouteListAPI";
 import EmptyUI from "@/components/EmptyUI";
 import LoadingSpinner from "@/components/LoadingSpinner";
+import RefetchButton from "@/components/RefetchButton";
 
 const { color, typography } = theme;
 
@@ -32,6 +34,8 @@ const TOOLTIP_DATA = {
 };
 
 const PathsPage = () => {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
   const [selectedDateFilter, setSelectedDateFilter] =
     useState<DateFilterValue>("TODAY");
   const [selectedStatusFilter, setSelectedStatusFilter] =
@@ -39,12 +43,24 @@ const PathsPage = () => {
   const [selectedPage, setSelectedPage] = useState(1);
   const ITEMS_PER_PAGE = 12;
 
+  const routeId = searchParams.get("routeId");
+  const pathId = routeId ? Number(routeId) : null;
+
   const { items, pageInfo, isFetching } = useGetRouteList(
     selectedDateFilter,
     selectedStatusFilter,
     selectedPage,
     ITEMS_PER_PAGE,
+    pathId,
   );
+
+  const handleRefetch = () => {
+    void navigate("/admin/book/paths", { replace: true });
+
+    setSelectedDateFilter("TODAY");
+    setSelectedStatusFilter("ALL");
+    setSelectedPage(1);
+  };
 
   useEffect(() => {
     setSelectedPage(1);
@@ -63,13 +79,21 @@ const PathsPage = () => {
 
       <section css={ToolbarStyle}>
         <div css={StatusSectionStyle}>
-          <h3 css={CountStyle}>총 {items.length}명</h3>
-          <StatusFilter
-            value={selectedStatusFilter}
-            options={ROUTE_STATUS_FILTER_OPTIONS}
-            setValue={setSelectedStatusFilter}
-          />
-          <ToolTip label={TOOLTIP_DATA.label} content={TOOLTIP_DATA.content} />
+          <div css={leftSectionStyle}>
+            <h3 css={CountStyle}>총 {items.length}명</h3>
+            <StatusFilter
+              value={selectedStatusFilter}
+              options={ROUTE_STATUS_FILTER_OPTIONS}
+              setValue={setSelectedStatusFilter}
+            />
+            <ToolTip
+              label={TOOLTIP_DATA.label}
+              content={TOOLTIP_DATA.content}
+            />
+          </div>
+          <div css={rightSectionStyle}>
+            <RefetchButton handleClick={handleRefetch} />
+          </div>
         </div>
       </section>
 
@@ -134,9 +158,9 @@ const ToolbarStyle = css`
 
 const StatusSectionStyle = css`
   display: flex;
-  gap: 24px;
+  width: 100%;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
 `;
 
 const CountStyle = css`
@@ -153,6 +177,19 @@ const LoadingSpinnerStyle = css`
   display: flex;
   width: 100%;
   height: 100%;
+  align-items: center;
+  justify-content: center;
+`;
+
+const leftSectionStyle = css`
+  display: flex;
+  gap: 24px;
+  align-items: center;
+  justify-content: center;
+`;
+
+const rightSectionStyle = css`
+  display: flex;
   align-items: center;
   justify-content: center;
 `;

--- a/frontend/src/pages/admin/book/UsersPage.tsx
+++ b/frontend/src/pages/admin/book/UsersPage.tsx
@@ -21,6 +21,7 @@ import { USER_STATUS_FILTER_OPTIONS } from "@/features/statusFilter/StatusFilter
 import { useGetBookList } from "@/apis/BookAPI";
 import EmptyUI from "@/components/EmptyUI";
 import LoadingSpinner from "@/components/LoadingSpinner";
+import RefetchButton from "@/components/RefetchButton";
 
 const { color, typography } = theme;
 
@@ -46,6 +47,12 @@ const UsersPage = () => {
     ITEMS_PER_PAGE,
   );
 
+  const handleRefetch = () => {
+    setSelectedDateFilter("TODAY");
+    setSelectedStatusFilter("ALL");
+    setSelectedPage(1);
+  };
+
   useEffect(() => {
     setSelectedPage(1);
   }, [selectedDateFilter, selectedStatusFilter]);
@@ -63,13 +70,21 @@ const UsersPage = () => {
 
       <section css={ToolbarStyle}>
         <div css={StatusSectionStyle}>
-          <h3 css={CountStyle}>총 {items.length}명</h3>
-          <StatusFilter
-            value={selectedStatusFilter}
-            options={USER_STATUS_FILTER_OPTIONS}
-            setValue={setSelectedStatusFilter}
-          />
-          <ToolTip label={TOOLTIP_DATA.label} content={TOOLTIP_DATA.content} />
+          <div css={leftSectionStyle}>
+            <h3 css={CountStyle}>총 {items.length}명</h3>
+            <StatusFilter
+              value={selectedStatusFilter}
+              options={USER_STATUS_FILTER_OPTIONS}
+              setValue={setSelectedStatusFilter}
+            />
+            <ToolTip
+              label={TOOLTIP_DATA.label}
+              content={TOOLTIP_DATA.content}
+            />
+          </div>
+          <div css={rightSectionStyle}>
+            <RefetchButton handleClick={handleRefetch} />
+          </div>
         </div>
       </section>
       <div css={TableSectionStyle}>
@@ -134,9 +149,9 @@ const ToolbarStyle = css`
 
 const StatusSectionStyle = css`
   display: flex;
-  gap: 24px;
+  width: 100%;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
 `;
 
 const CountStyle = css`
@@ -153,6 +168,19 @@ const LoadingSpinnerStyle = css`
   display: flex;
   width: 100%;
   height: 100%;
+  align-items: center;
+  justify-content: center;
+`;
+
+const leftSectionStyle = css`
+  display: flex;
+  gap: 24px;
+  align-items: center;
+  justify-content: center;
+`;
+
+const rightSectionStyle = css`
+  display: flex;
   align-items: center;
   justify-content: center;
 `;

--- a/frontend/src/pages/admin/book/UsersPage.tsx
+++ b/frontend/src/pages/admin/book/UsersPage.tsx
@@ -93,7 +93,10 @@ const UsersPage = () => {
             <LoadingSpinner size="large" />
           </div>
         ) : items.length > 0 ? (
-          <TableWithIndex rows={items} />
+          <TableWithIndex
+            rows={items}
+            selectedDateFilter={selectedDateFilter}
+          />
         ) : (
           <EmptyUI />
         )}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Close #340 
- Close #70 

## 📝 기능 설명
예약자 페이지에서 예약자의 경로 id를 클릭했을 때, 해당 id값의 경로를 보여주게 라우팅했습니다.

## 🛠 작업 사항
- 테이블 컴포넌트에서, routId쪽에 핸들러 함수를 추가했습니다.
- 해당 경로 데이터만 보여주기 때문에, refetch 컴포넌트를 재사용하여 클릭시 전체 id 데이터를 다시 불러오게 했습니다.

## ✅ 작업 항목
- [x] 경로 Id기반 운행경로 페이지로 라우팅
- [x] refetch 버튼 추가

## 📎 참고 자료

https://github.com/user-attachments/assets/9540c752-ab5e-4089-abeb-ae072119a1f0

