### PR TITLE
[Feat/#292-343] Polling 기능 구현

### DIFF
--- a/frontend/src/apis/BookAPI.ts
+++ b/frontend/src/apis/BookAPI.ts
@@ -3,25 +3,51 @@ import { APIMatcher } from "@/utils/APIMatcher";
 import { clientInstance } from "@/utils/AxiosInstance";
 import TabMatcher from "@/utils/TabMatcher";
 import { useQuery } from "@tanstack/react-query";
+import { useRef } from "react";
 
 export const useGetBook = (activeTab: string) => {
+  // book status 서버용으로 변환
   const engBookStatus = TabMatcher.matchBookTypeKRToENG(activeTab);
   const bookStatus = TabMatcher.matchBookTypeClientToServer(engBookStatus);
-  const { data, isFetching, refetch } = useQuery<BookAPIResponse>({
+
+  // polling 주기 관리
+  const minInterval = 5000;
+  const maxInterval = 60000;
+  const intervalRef = useRef(minInterval);
+
+  const query = useQuery<BookAPIResponse>({
     queryKey: ["book", bookStatus],
     queryFn: () =>
       clientInstance.get(
         `/book/scroll?status=${bookStatus}&lastId=&lastCreatedAt=&size=100`,
       ),
     throwOnError: true,
-    refetchInterval: 600000,
+    refetchInterval: (query) => {
+      /**
+       * polling
+       * - 에러 발생시 interval 2배
+       * - 통신 성공+새 데이터 발생시 interval 최소값으로 설정
+       * - 통신 성공+새 데이터 없을시 interval 2배
+       */
+      if (query.state.error) {
+        intervalRef.current = Math.min(intervalRef.current * 2, maxInterval);
+      } else if (query.state.data && query.state.data?.data.items?.length > 0) {
+        intervalRef.current = minInterval;
+      } else {
+        intervalRef.current = Math.min(intervalRef.current * 2, maxInterval);
+      }
+      console.log(intervalRef.current);
+      return intervalRef.current;
+    },
   });
-  const bookData = data?.data.items.map((partData) =>
+
+  const bookData = query.data?.data.items.map((partData) =>
     APIMatcher.matchBookAPI(partData),
   );
+
   return {
     data: bookData,
-    isFetching,
-    refetch,
+    isFetching: query.isFetching,
+    refetch: query.refetch,
   };
 };

--- a/frontend/src/apis/BookAPI.ts
+++ b/frontend/src/apis/BookAPI.ts
@@ -7,20 +7,21 @@ import { useQuery } from "@tanstack/react-query";
 export const useGetBook = (activeTab: string) => {
   const engBookStatus = TabMatcher.matchBookTypeKRToENG(activeTab);
   const bookStatus = TabMatcher.matchBookTypeClientToServer(engBookStatus);
-  const { data, error, refetch } = useQuery<BookAPIResponse>({
+  const { data, isFetching, refetch } = useQuery<BookAPIResponse>({
     queryKey: ["book", bookStatus],
     queryFn: () =>
       clientInstance.get(
         `/book/scroll?status=${bookStatus}&lastId=&lastCreatedAt=&size=100`,
       ),
     throwOnError: true,
+    refetchInterval: 600000,
   });
   const bookData = data?.data.items.map((partData) =>
     APIMatcher.matchBookAPI(partData),
   );
   return {
     data: bookData,
-    error,
+    isFetching,
     refetch,
   };
 };

--- a/frontend/src/apis/BookAPI.ts
+++ b/frontend/src/apis/BookAPI.ts
@@ -20,8 +20,8 @@ export const useGetBook = (activeTab: string) => {
   const bookStatus = TabMatcher.matchBookTypeClientToServer(engBookStatus);
 
   // polling 주기 관리
-  const minInterval = 60000;
-  const maxInterval = 80000;
+  const minInterval = 60000; //1분
+  const maxInterval = 12000; //2분
   const intervalRef = useRef(minInterval);
 
   const query = useQuery<BookAPIResponse>({

--- a/frontend/src/apis/BookAPI.ts
+++ b/frontend/src/apis/BookAPI.ts
@@ -1,4 +1,8 @@
-import type { BookAPIData, BookAPIResponse, BookData } from "@/features/book/Book.types";
+import type {
+  BookAPIData,
+  BookAPIResponse,
+  BookData,
+} from "@/features/book/Book.types";
 import type { DateFilterValue } from "@/features/dateFilter/DateFilter.constants";
 import type { UserFilterValue } from "@/features/statusFilter/StatusFilter.constants";
 import { APIMatcher } from "@/utils/APIMatcher";
@@ -34,8 +38,8 @@ export const useGetBook = (activeTab: string) => {
   const bookStatus = TabMatcher.matchBookTypeClientToServer(engBookStatus);
 
   // polling 주기 관리
-  const minInterval = 30000; //30초
-  const maxInterval = 60000; //1분
+  const minInterval = 0.5 * 60000; //30초
+  const maxInterval = 1 * 60000; //1분
   const intervalRef = useRef(minInterval);
 
   const query = useQuery<BookAPIResponse>({

--- a/frontend/src/apis/BookAPI.ts
+++ b/frontend/src/apis/BookAPI.ts
@@ -45,7 +45,6 @@ export const useGetBook = (activeTab: string) => {
       } else {
         intervalRef.current = Math.min(intervalRef.current * 2, maxInterval);
       }
-      console.log(intervalRef.current);
       return intervalRef.current;
     },
   });
@@ -57,7 +56,6 @@ export const useGetBook = (activeTab: string) => {
   // 탭 변경 감지 및 초기화
   useEffect(() => {
     if (prevTabRef.current !== activeTab) {
-      // 탭이 변경되면 상태 초기화
       setVisibleData([]);
       setPendingData([]);
       setIsNewDataActive(false);
@@ -80,7 +78,6 @@ export const useGetBook = (activeTab: string) => {
       ]);
 
       const newItems = bookData.filter((item) => !existingIds.has(item.id));
-
       if (newItems.length > 0) {
         setPendingData((prev) => [...newItems, ...prev]);
         setIsNewDataActive(true);
@@ -88,6 +85,7 @@ export const useGetBook = (activeTab: string) => {
     }
   }, [bookData, visibleData, pendingData]);
 
+  // visible Data에 pending Data 수동 병합
   const mergePendingToVisible = () => {
     setVisibleData((prev) => [...pendingData, ...prev]);
     setPendingData([]);

--- a/frontend/src/apis/BookAPI.ts
+++ b/frontend/src/apis/BookAPI.ts
@@ -20,8 +20,8 @@ export const useGetBook = (activeTab: string) => {
   const bookStatus = TabMatcher.matchBookTypeClientToServer(engBookStatus);
 
   // polling 주기 관리
-  const minInterval = 60000; //1분
-  const maxInterval = 12000; //2분
+  const minInterval = 30000; //30초
+  const maxInterval = 60000; //1분
   const intervalRef = useRef(minInterval);
 
   const query = useQuery<BookAPIResponse>({

--- a/frontend/src/apis/ScheduleAPI.ts
+++ b/frontend/src/apis/ScheduleAPI.ts
@@ -17,8 +17,8 @@ export const useGetEntireSchedule = (activeTab: string) => {
     TabMatcher.matchScheduleTypeClientToServer(engScheduleStatus);
 
   // polling 주기 관리
-  const minInterval = 6000; //1분
-  const maxInterval = 1200; //2분
+  const minInterval = 60000; //1분
+  const maxInterval = 12000; //2분
   const intervalRef = useRef(minInterval);
 
   const { data, isFetching, refetch } = useSuspenseQuery<ScheduleAPIResposne>({

--- a/frontend/src/apis/ScheduleAPI.ts
+++ b/frontend/src/apis/ScheduleAPI.ts
@@ -17,8 +17,8 @@ export const useGetEntireSchedule = (activeTab: string) => {
     TabMatcher.matchScheduleTypeClientToServer(engScheduleStatus);
 
   // polling 주기 관리
-  const minInterval = 60000; //1분
-  const maxInterval = 12000; //2분
+  const minInterval = 1 * 60000; //1분
+  const maxInterval = 2 * 60000; //2분
   const intervalRef = useRef(minInterval);
 
   const { data, isFetching, refetch } = useSuspenseQuery<ScheduleAPIResposne>({

--- a/frontend/src/apis/ScheduleAPI.ts
+++ b/frontend/src/apis/ScheduleAPI.ts
@@ -1,7 +1,7 @@
 import type {
   NodeAPIReponse,
   PassengerAPIResponse,
-  ScheduleAPIResposne,
+  ScheduleAPIResponse,
 } from "@/features/schedule/Schedule.types";
 import { APIMatcher } from "@/utils/APIMatcher";
 import { clientInstance } from "@/utils/AxiosInstance";
@@ -21,7 +21,7 @@ export const useGetEntireSchedule = (activeTab: string) => {
   const maxInterval = 2 * 60000; //2분
   const intervalRef = useRef(minInterval);
 
-  const { data, isFetching, refetch } = useSuspenseQuery<ScheduleAPIResposne>({
+  const { data, isFetching, refetch } = useSuspenseQuery<ScheduleAPIResponse>({
     queryKey: ["schedule", scheduleStatus],
     queryFn: () =>
       clientInstance.get(`/path/scroll?status=${scheduleStatus}&size=100`),

--- a/frontend/src/components/RefetchButton.tsx
+++ b/frontend/src/components/RefetchButton.tsx
@@ -3,18 +3,32 @@ import { rotating, ROTATING_TIME } from "@/utils/RotateAnimation";
 import { theme } from "@/styles/themes.style";
 import DateFormatter from "@/utils/DateFormatter";
 import { css } from "@emotion/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 const { color, typography } = theme;
 
 interface RefetchButtonProps {
+  isFetching?: boolean;
   handleClick: () => void;
 }
-const RefetchButton = ({ handleClick }: RefetchButtonProps) => {
+const RefetchButton = ({
+  isFetching = false,
+  handleClick,
+}: RefetchButtonProps) => {
   const [refetchTime, setRefetchTime] = useState(
     DateFormatter.formatDateToSplitTime(new Date()),
   );
   const [isRefetchActive, setIsRefetchActive] = useState(false);
 
+  // 자동 업데이트: polling
+  useEffect(() => {
+    if (isFetching) {
+      setIsRefetchActive(true);
+      setRefetchTime(DateFormatter.formatDateToSplitTime(new Date()));
+      setTimeout(() => setIsRefetchActive(false), ROTATING_TIME * 1000);
+    }
+  }, [isFetching]);
+
+  // 수동 업데이트
   const handleRefetch = () => {
     setIsRefetchActive(true);
     handleClick();

--- a/frontend/src/components/RefetchButton.tsx
+++ b/frontend/src/components/RefetchButton.tsx
@@ -29,15 +29,17 @@ const RefetchButton = ({
   }, [isFetching]);
 
   // 수동 업데이트
-  const handleRefetch = () => {
-    setIsRefetchActive(true);
-    handleClick();
-    setRefetchTime(DateFormatter.formatDateToSplitTime(new Date()));
-    setTimeout(() => setIsRefetchActive(false), ROTATING_TIME * 1000);
+  const handleManualRefetch = () => {
+    if (!isFetching) {
+      setIsRefetchActive(true);
+      handleClick();
+      setRefetchTime(DateFormatter.formatDateToSplitTime(new Date()));
+      setTimeout(() => setIsRefetchActive(false), ROTATING_TIME * 1000);
+    }
   };
 
   return (
-    <div css={RefetchButtonContainer} onClick={handleRefetch}>
+    <div css={RefetchButtonContainer} onClick={handleManualRefetch}>
       <p css={DateText}>{refetchTime}</p>
       <RefreashIcon
         css={isRefetchActive ? rotating() : undefined}

--- a/frontend/src/features/book/Book.types.ts
+++ b/frontend/src/features/book/Book.types.ts
@@ -42,4 +42,12 @@ export interface BookAPIData {
   endAddr: string;
   walker: boolean;
   bookStatus: BookStatus;
+  path: {
+    pathId: string;
+    carNumber: string;
+    startTime: string;
+    endTime: string;
+    startAddr: string;
+    endAddr: string;
+  } | null;
 }

--- a/frontend/src/features/book/BookCard.style.ts
+++ b/frontend/src/features/book/BookCard.style.ts
@@ -25,9 +25,10 @@ const BookCardContainer = (isActive: boolean) => css`
   flex-direction: column;
   gap: 20px;
   border-radius: 20px;
+  cursor: pointer;
 
   &:hover {
-    background-color: ${color.GrayScale.gray1};
+    background-color: ${color.GrayScale.gray2};
   }
 
   ${isActive &&

--- a/frontend/src/features/book/BookDetailSection.tsx
+++ b/frontend/src/features/book/BookDetailSection.tsx
@@ -9,7 +9,7 @@ import { css } from "@emotion/react";
 const { typography } = theme;
 
 interface BookDetailSectionProps {
-  data: BookData | undefined;
+  data: BookData | null;
   activeTab: string;
 }
 

--- a/frontend/src/features/book/BookListSection.tsx
+++ b/frontend/src/features/book/BookListSection.tsx
@@ -50,6 +50,12 @@ const BookListSection = ({
     }
   };
 
+  const matchTagColor = (activeTab: string) => {
+    if (activeTab === "신규 예약") return "orange";
+    if (activeTab === "예약 성공") return "blue";
+    return "red";
+  };
+
   return (
     <div css={BookListSectionContainer}>
       <div css={HeaderContainer}>
@@ -64,7 +70,10 @@ const BookListSection = ({
       />
       {isNewDataActive && (
         <div onClick={handleMergeNewData} css={NewDataWrapper}>
-          <Tag type="orange" label={`새로운 예약: ${pendingCount}건`} />
+          <Tag
+            type={matchTagColor(activeTab)}
+            label={`새로운 예약: ${pendingCount}건`}
+          />
         </div>
       )}
       <div ref={contentContainerRef} css={ContentContainer}>

--- a/frontend/src/features/book/BookListSection.tsx
+++ b/frontend/src/features/book/BookListSection.tsx
@@ -5,31 +5,41 @@ import BookCard from "@/features/book/BookCard";
 import { bookDataList } from "@/mocks/bookMocks";
 import { theme } from "@/styles/themes.style";
 import TabMatcher from "@/utils/TabMatcher";
-import { css } from "@emotion/react";
-import { type Dispatch, type SetStateAction } from "react";
+import { css, keyframes } from "@emotion/react";
+import { useEffect, type Dispatch, type SetStateAction } from "react";
+import { useGetBook } from "@/apis/BookAPI";
 import type { BookData } from "@/features/book/Book.types";
+import Tag from "@/components/Tag";
 const { color, typography } = theme;
 
 interface BookListSectionProps {
-  data: BookData[] | undefined;
   activeTab: string;
-  activeBookId: number | null;
   setActiveTab: Dispatch<SetStateAction<string>>;
-  setActiveBookId: Dispatch<SetStateAction<number | null>>;
-  isFetching: boolean;
-  refetch: () => void;
+  activeBookData: BookData | null;
+  setActiveBookData: Dispatch<SetStateAction<BookData | null>>;
 }
 const BookListSection = ({
-  data,
   activeTab,
-  activeBookId,
   setActiveTab,
-  setActiveBookId,
-  isFetching,
-  refetch,
+  activeBookData,
+  setActiveBookData,
 }: BookListSectionProps) => {
   const TAB_LIST = ["신규 예약", "예약 성공", "예약 실패"];
   const LOCATION_SECTION = "운정 1구역";
+
+  const {
+    visibleData: data,
+    isNewDataActive,
+    pendingCount,
+    mergePendingToVisible,
+    isFetching,
+    refetch,
+  } = useGetBook(activeTab);
+
+  // 첫 번째 인덱스의 값 초기값으로 설정
+  useEffect(() => {
+    setActiveBookData(data[0]);
+  }, [data, setActiveBookData]);
 
   return (
     <div css={BookListSectionContainer}>
@@ -43,17 +53,22 @@ const BookListSection = ({
         selected={activeTab}
         setSelected={setActiveTab}
       />
+      {isNewDataActive && (
+        <div onClick={mergePendingToVisible} css={NewDataWrapper}>
+          <Tag type="blue" label={`새로운 예약: ${pendingCount}건`} />
+        </div>
+      )}
       <div css={ContentContainer}>
         {data && data?.length > 0 ? (
           data.map((bookData, idx) => (
             <div
               key={`${activeTab}-${bookData.id}`}
-              onClick={() => setActiveBookId(bookData.id)}
+              onClick={() => setActiveBookData(bookData)}
             >
               <BookCard
                 bookType={TabMatcher.matchBookTypeKRToENG(activeTab)}
                 data={bookData}
-                isActive={bookData.id === activeBookId}
+                isActive={bookData.id === activeBookData?.id}
               />
               {idx !== bookDataList.length - 1 && <div css={LineWrapper} />}
             </div>
@@ -96,6 +111,28 @@ const LineWrapper = css`
   width: 405px;
   border-bottom: 1px solid ${color.GrayScale.gray3};
   margin: 20px auto;
+`;
+
+const popIn = keyframes`
+  0% {
+    transform: scale(0.5);
+    opacity: 0;
+  }
+  70% {
+    transform: scale(1.2);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+`;
+
+export const NewDataWrapper = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  animation: ${popIn} 0.5s ease-out;
 `;
 
 const LocationSectionText = css`

--- a/frontend/src/features/book/BookListSection.tsx
+++ b/frontend/src/features/book/BookListSection.tsx
@@ -62,11 +62,11 @@ const BookListSection = ({
         selected={activeTab}
         setSelected={setActiveTab}
       />
-      {
+      {isNewDataActive && (
         <div onClick={handleMergeNewData} css={NewDataWrapper}>
           <Tag type="orange" label={`새로운 예약: ${pendingCount}건`} />
         </div>
-      }
+      )}
       <div ref={contentContainerRef} css={ContentContainer}>
         {data && data?.length > 0 ? (
           data.map((bookData, idx) => (

--- a/frontend/src/features/book/BookListSection.tsx
+++ b/frontend/src/features/book/BookListSection.tsx
@@ -6,7 +6,7 @@ import { bookDataList } from "@/mocks/bookMocks";
 import { theme } from "@/styles/themes.style";
 import TabMatcher from "@/utils/TabMatcher";
 import { css, keyframes } from "@emotion/react";
-import { useEffect, type Dispatch, type SetStateAction } from "react";
+import { useEffect, useRef, type Dispatch, type SetStateAction } from "react";
 import { useGetBook } from "@/apis/BookAPI";
 import type { BookData } from "@/features/book/Book.types";
 import Tag from "@/components/Tag";
@@ -26,6 +26,7 @@ const BookListSection = ({
 }: BookListSectionProps) => {
   const TAB_LIST = ["신규 예약", "예약 성공", "예약 실패"];
   const LOCATION_SECTION = "운정 1구역";
+  const contentContainerRef = useRef<HTMLDivElement>(null);
 
   const {
     visibleData: data,
@@ -41,6 +42,14 @@ const BookListSection = ({
     setActiveBookData(data[0]);
   }, [data, setActiveBookData]);
 
+  // polling 성공시 새로운 데이터 발생한 경우 반영하는 로직
+  const handleMergeNewData = () => {
+    mergePendingToVisible();
+    if (contentContainerRef.current) {
+      contentContainerRef.current.scrollTo({ top: 0, behavior: "smooth" });
+    }
+  };
+
   return (
     <div css={BookListSectionContainer}>
       <div css={HeaderContainer}>
@@ -53,12 +62,12 @@ const BookListSection = ({
         selected={activeTab}
         setSelected={setActiveTab}
       />
-      {isNewDataActive && (
-        <div onClick={mergePendingToVisible} css={NewDataWrapper}>
-          <Tag type="blue" label={`새로운 예약: ${pendingCount}건`} />
+      {
+        <div onClick={handleMergeNewData} css={NewDataWrapper}>
+          <Tag type="orange" label={`새로운 예약: ${pendingCount}건`} />
         </div>
-      )}
-      <div css={ContentContainer}>
+      }
+      <div ref={contentContainerRef} css={ContentContainer}>
         {data && data?.length > 0 ? (
           data.map((bookData, idx) => (
             <div
@@ -133,6 +142,7 @@ export const NewDataWrapper = css`
   justify-content: center;
   align-items: center;
   animation: ${popIn} 0.5s ease-out;
+  cursor: pointer;
 `;
 
 const LocationSectionText = css`

--- a/frontend/src/features/book/BookListSection.tsx
+++ b/frontend/src/features/book/BookListSection.tsx
@@ -16,6 +16,7 @@ interface BookListSectionProps {
   activeBookId: number | null;
   setActiveTab: Dispatch<SetStateAction<string>>;
   setActiveBookId: Dispatch<SetStateAction<number | null>>;
+  isFetching: boolean;
   refetch: () => void;
 }
 const BookListSection = ({
@@ -24,6 +25,7 @@ const BookListSection = ({
   activeBookId,
   setActiveTab,
   setActiveBookId,
+  isFetching,
   refetch,
 }: BookListSectionProps) => {
   const TAB_LIST = ["신규 예약", "예약 성공", "예약 실패"];
@@ -33,7 +35,7 @@ const BookListSection = ({
     <div css={BookListSectionContainer}>
       <div css={HeaderContainer}>
         <p css={LocationSectionText}>{LOCATION_SECTION}</p>
-        <RefetchButton handleClick={refetch} />
+        <RefetchButton isFetching={isFetching} handleClick={refetch} />
       </div>
       <Tabs
         type="bar_true"

--- a/frontend/src/features/book/BookSection.tsx
+++ b/frontend/src/features/book/BookSection.tsx
@@ -8,7 +8,7 @@ const BookSection = () => {
   const [activeTab, setActiveTab] = useState<string>("신규 예약");
   const [activeBookId, setActiveBookId] = useState<number | null>(null);
 
-  const { data, refetch } = useGetBook(activeTab);
+  const { data, isFetching, refetch } = useGetBook(activeTab);
   const activeBookData = data?.find(
     (book) => book.id === (activeBookId ?? data[0].id),
   );
@@ -21,6 +21,7 @@ const BookSection = () => {
         setActiveTab={setActiveTab}
         activeBookId={activeBookId}
         setActiveBookId={setActiveBookId}
+        isFetching={isFetching}
         refetch={refetch}
       />
       <BookDetailSection data={activeBookData} activeTab={activeTab} />

--- a/frontend/src/features/book/BookSection.tsx
+++ b/frontend/src/features/book/BookSection.tsx
@@ -1,4 +1,4 @@
-import { useGetBook } from "@/apis/BookAPI";
+import type { BookData } from "@/features/book/Book.types";
 import BookDetailSection from "@/features/book/BookDetailSection";
 import BookListSection from "@/features/book/BookListSection";
 import { css } from "@emotion/react";
@@ -6,23 +6,15 @@ import { useState } from "react";
 
 const BookSection = () => {
   const [activeTab, setActiveTab] = useState<string>("신규 예약");
-  const [activeBookId, setActiveBookId] = useState<number | null>(null);
-
-  const { data, isFetching, refetch } = useGetBook(activeTab);
-  const activeBookData = data?.find(
-    (book) => book.id === (activeBookId ?? data[0].id),
-  );
+  const [activeBookData, setActiveBookData] = useState<BookData | null>(null);
 
   return (
     <div css={BookPageContainer}>
       <BookListSection
-        data={data}
         activeTab={activeTab}
         setActiveTab={setActiveTab}
-        activeBookId={activeBookId}
-        setActiveBookId={setActiveBookId}
-        isFetching={isFetching}
-        refetch={refetch}
+        activeBookData={activeBookData}
+        setActiveBookData={setActiveBookData}
       />
       <BookDetailSection data={activeBookData} activeTab={activeTab} />
     </div>

--- a/frontend/src/features/schedule/Schedule.types.ts
+++ b/frontend/src/features/schedule/Schedule.types.ts
@@ -20,7 +20,7 @@ export interface ScheduleData {
   carNumber: string;
 }
 
-export interface ScheduleAPIResposne {
+export interface ScheduleAPIResponse {
   isSuccess: boolean;
   code: number;
   message: string;

--- a/frontend/src/features/schedule/ScheduleDataFetcher.tsx
+++ b/frontend/src/features/schedule/ScheduleDataFetcher.tsx
@@ -16,18 +16,24 @@ const ScheduleDataFetcher = ({
   selectedSchedule,
   setSelectedSchedule,
   setRefetchFn,
+  setIsFetching,
 }: {
   activeTab: string;
   parsedActiveTab: ScheduleType;
   selectedSchedule: Partial<ScheduleData | null>;
   setSelectedSchedule: Dispatch<SetStateAction<Partial<ScheduleData | null>>>;
   setRefetchFn: (refetch: () => void) => void;
+  setIsFetching: (fetching: boolean) => void;
 }) => {
-  const { data, refetch } = useGetEntireSchedule(activeTab);
+  const { data, isFetching, refetch } = useGetEntireSchedule(activeTab);
 
   useEffect(() => {
     setRefetchFn(refetch);
   }, [refetch, setRefetchFn]);
+
+  useEffect(() => {
+    setIsFetching(isFetching);
+  }, [isFetching, setIsFetching]);
 
   useEffect(() => {
     if (data && data.length > 0 && !selectedSchedule?.routeId) {

--- a/frontend/src/features/schedule/ScheduleListSection.tsx
+++ b/frontend/src/features/schedule/ScheduleListSection.tsx
@@ -10,7 +10,13 @@ import ScheduleDataFetcher from "@/features/schedule/ScheduleDataFetcher";
 import { theme } from "@/styles/themes.style";
 import { css } from "@emotion/react";
 import { QueryErrorResetBoundary } from "@tanstack/react-query";
-import { Suspense, useRef, type Dispatch, type SetStateAction } from "react";
+import {
+  Suspense,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction,
+} from "react";
 import { ErrorBoundary } from "react-error-boundary";
 const { color, typography } = theme;
 
@@ -32,12 +38,16 @@ const ScheduleListSection = ({
 }: ScheduleListSectionProps) => {
   const LOCATION_SECTION = "운정 1구역";
   const refetchFnRef = useRef<() => void>(() => {});
+  const [isFetching, setIsFetching] = useState(false);
 
   return (
     <div css={ScheduleListSectionContainer}>
       <div css={HeaderContainer}>
         <p css={LocationSectionText}>{LOCATION_SECTION}</p>
-        <RefetchButton handleClick={() => refetchFnRef.current()} />
+        <RefetchButton
+          isFetching={isFetching}
+          handleClick={() => refetchFnRef.current()}
+        />
       </div>
       <Tabs
         type="bar_true"
@@ -62,6 +72,7 @@ const ScheduleListSection = ({
                   selectedSchedule={selectedSchedule}
                   setSelectedSchedule={setSelectedSchedule}
                   setRefetchFn={(refetch) => (refetchFnRef.current = refetch)}
+                  setIsFetching={setIsFetching}
                 />
               </Suspense>
             </ErrorBoundary>

--- a/frontend/src/utils/APIMatcher.ts
+++ b/frontend/src/utils/APIMatcher.ts
@@ -7,24 +7,25 @@ import type {
 export const APIMatcher = {
   matchBookAPI: (apiItem: BookAPIData): BookData => {
     return {
+      //예약자
       id: apiItem.id,
       bookStatus: apiItem.bookStatus,
       name: apiItem.bookName,
       phone: apiItem.bookTel,
       isExistWalkingDevice: apiItem.walker,
+      //예약
       bookTime: apiItem.bookTime,
       bookDate: apiItem.bookDate,
       userStartLocation: apiItem.startAddr,
       userEndLocation: apiItem.endAddr,
       hospitalTime: apiItem.hospitalTime,
-
-      // 아직 API에서 안 오는 값들은 일단 빈값 처리
-      routeId: "",
-      carNumber: "",
-      routeStartTime: "",
-      routeEndTime: "",
-      routeStartLocation: "",
-      routeEndLocation: "",
+      // 경로
+      routeId: apiItem.path?.pathId ?? "",
+      carNumber: apiItem.path?.carNumber ?? "",
+      routeStartTime: apiItem.path?.startTime ?? "",
+      routeEndTime: apiItem.path?.endTime ?? "",
+      routeStartLocation: apiItem.path?.startAddr ?? "",
+      routeEndLocation: apiItem.path?.endAddr ?? "",
     };
   },
   matchScheduleAPI: (apiItem: ScheduleAPIData) => {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Close #292 
- Close #343 

## 📝 기능 설명
실시간 정보를 제공하기 위해 `Polling`을 도입했습니다.
- 실시간 예약 현황
- 실시간 운행 현황

## 🛠 작업 사항
### 주기적인 Polling으로 실시간 보장
- 실시간 예약 현황: 30초-1분으로 지속적으로 데이터를 가져옵니다
- 실시간 운행 현황: 1분-2분으로 지속적으로 데이터를 가져옵니다

해당하는 Polling 주기가 되면 데이터를 다시 fetch하게 됩니다. 상단에 존재하는 refetch 버튼이  회전하며, 현재 시간을 반영해 fetch가 되었음을 시각적으로 확인할 수 있습니다.

### 동적으로 Polling 시간 할당
- Adaptive: 새로운 데이터가 들어오는 경우 `짧은 interval`, 새로운 데이터가 들어오지 않는 경우 `Interval *= 2`
- Exponential Backoff Polling: 실패하는 경우 `interval *= 2`

### Polling시 알림 기능 제공
- 새로운 데이터 들어오는 경우 알림 등장
- 알림 클릭하면 스크롤 최상단으로 이동

https://github.com/user-attachments/assets/a0b62f56-cbf8-44fb-b911-099e8ab1544a

### 수동 데이터 패칭 VS 자동 데이터 패칭
- 수동 데이터 패칭: Refetch button 클릭
- 자동 데이터 패칭: useQeury-useSuspenseQuery의 refetchInterval 동작
두 개의 패칭이 중복될 가능성이 존재하기에, 수동 데이터 패칭에서 자동 데이터 패칭 상태인 경우 동작을 하지 않는 플래그를 설정했습니다!

### 자세한 기록: [실시간 데이터 정보: polling으로 refresh!](https://spiffy-centipede-875.notion.site/polling-refresh-25662570e7c480cab46bf1aa87ce6a17?pvs=74)
## ✅ 작업 항목
### 실시간 예약 현황
- [x] Polling 구현
- [x] Polling 전략 도입
  - [x] Adaptive
  - [x] Exponential Backoff 
- [x] Polling 이전값-Polling 이후 값 연동
- [x] Polling 이후 새로고침 클릭시 스크롤 위치 조정
- [x] Polling 진행시 부드러운 스크롤 이동 구현
- [x] 경로 성공시 경로값 할당

### 실시간 운행 현황
- [x] Polling 구현
- [x] Polling 값 반영
- [x] Polling-수동 업데이트 겹치는 순간 문제 해결

## 📎 참고 자료
화면에 보여주기기 위해 실제 주기보다 2배 빠르게 진행했습니다! 👀 
### 실시간 예약 현황에서의 Polling

https://github.com/user-attachments/assets/20e5347c-31b6-450d-949c-b5f4b674762f


### 실시간 운행 현황에서의 Polling

https://github.com/user-attachments/assets/1295018b-a2bf-4204-9578-7a02f3e21dae

