### PR TITLE
[Fix/#362] 해상도 비율 수정 (100% 기준 레이아웃 정상화)

### DIFF
--- a/frontend/src/components/CarModalContent.tsx
+++ b/frontend/src/components/CarModalContent.tsx
@@ -56,13 +56,13 @@ export default CarModalContent;
 const CardContainer = css`
   display: flex;
   background-color: ${color.GrayScale.white};
-  width: 346px;
+  width: 320px;
   align-items: center;
   justify-content: center;
-  padding: 28px;
+  padding: 23px;
   border-radius: ${borderRadius.Medium};
   flex-direction: column;
-  gap: 38px;
+  gap: 28px;
 `;
 
 const TextSection = css`
@@ -74,12 +74,12 @@ const TextSection = css`
 `;
 
 const HeaderText = css`
-  font: ${typography.Heading.h3_semi};
+  font: ${typography.Heading.h4_semi};
   color: ${color.GrayScale.black};
 `;
 
 const HighlightedText = css`
-  font: ${typography.Heading.h3_semi};
+  font: ${typography.Heading.h4_semi};
   color: ${color.Maincolor.primary};
 `;
 const ContentText = css`

--- a/frontend/src/components/ModalContent.tsx
+++ b/frontend/src/components/ModalContent.tsx
@@ -38,13 +38,13 @@ const CardContainer = css`
 `;
 
 const TextStyle = css`
-  font: ${typography.Heading.h3_semi};
+  font: ${typography.Heading.h5_semi};
   color: ${color.GrayScale.black};
 `;
 
 const AlertTextStyle = css`
   text-align: center;
-  font: ${typography.Heading.h4_semi};
+  font: ${typography.Label.l3_semi};
   color: ${color.GrayScale.black};
   overflow: hidden;
   display: -webkit-box;

--- a/frontend/src/features/book/BookListSection.tsx
+++ b/frontend/src/features/book/BookListSection.tsx
@@ -104,7 +104,7 @@ export default BookListSection;
 const BookListSectionContainer = css`
   min-width: 485px;
   max-width: 485px;
-  height: calc(100vh - 72px);
+  height: calc(125dvh - 72px);
   display: flex;
   flex-direction: column;
   gap: 24px;

--- a/frontend/src/features/schedule/ScheduleListSection.tsx
+++ b/frontend/src/features/schedule/ScheduleListSection.tsx
@@ -88,7 +88,7 @@ export default ScheduleListSection;
 const ScheduleListSectionContainer = css`
   min-width: 485px;
   max-width: 485px;
-  height: calc(100vh - 72px);
+  height: calc(125vh - 72px);
   display: flex;
   flex-direction: column;
   gap: 24px;

--- a/frontend/src/layouts/AdminLayout.tsx
+++ b/frontend/src/layouts/AdminLayout.tsx
@@ -17,6 +17,6 @@ export default AdminLayout;
 
 const ContentContainer = css`
   position: relative;
-  height: calc(100dvh - 72px);
   top: 72px;
+  width: 125vw;
 `;

--- a/frontend/src/layouts/BookLayout.tsx
+++ b/frontend/src/layouts/BookLayout.tsx
@@ -22,13 +22,13 @@ const SidebarContainer = css`
   top: 72px;
   left: 0;
   width: 330px;
-  height: calc(100dvh - 72px);
+  height: calc(125dvh - 72px);
 `;
 
 const ContentContainer = css`
   position: relative;
-  width: calc(100dvw - 330px);
-  height: calc(100dvh - 72px);
+  width: calc(125dvw - 330px);
+  height: calc(125dvh - 72px);
   left: 330px;
   top: 0;
 `;

--- a/frontend/src/layouts/CenterLayout.tsx
+++ b/frontend/src/layouts/CenterLayout.tsx
@@ -19,6 +19,6 @@ export default CenterLayout;
 
 const ContentContainer = css`
   position: relative;
-  height: 100%;
+  height: calc(125dvh - 72px);
   top: 72px;
 `;

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -35,7 +35,7 @@ export default LandingPage;
 
 const LandingPageContainer = css`
   display: flex;
-  height: 100vh;
+  height: 125vh;
   width: 100%;
   overflow: hidden;
 `;

--- a/frontend/src/pages/admin/centers/CenterDetailPage.tsx
+++ b/frontend/src/pages/admin/centers/CenterDetailPage.tsx
@@ -112,7 +112,6 @@ const CenterDetailPage = () => {
 export default CenterDetailPage;
 
 const PageContainer = css`
-  width: 100vw;
   display: flex;
   flex-direction: column;
   align-items: flex-start;

--- a/frontend/src/pages/center/CenterPage.tsx
+++ b/frontend/src/pages/center/CenterPage.tsx
@@ -231,7 +231,6 @@ const CenterPage = () => {
 export default CenterPage;
 
 const PageContainer = css`
-  width: 100vw;
   display: flex;
   flex-direction: column;
   align-items: flex-start;

--- a/frontend/src/styles/global.style.css
+++ b/frontend/src/styles/global.style.css
@@ -18,3 +18,9 @@ body {
   background-color: #ffffff;
   color: #212121;
 }
+
+#root {
+  zoom: 0.8;
+  height: 100%;
+  width: 100%;
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- Close #362 

## 📝 기능 설명
기존에는 브라우저 줌 비율 80%에서만 정상적으로 보이던 레이아웃을 100% 줌 비율에서도 동일하게 보이도록 해상도 스타일을 수정했습니다.

## 🛠 작업 사항
- 레이아웃 스타일 조정
- zoom 80%로 지정
- 100% 기준 레이아웃 적용

## ✅ 작업 항목
- [x] 100% 줌에서 레이아웃 정상 표시 확인
- [x] 주요 컴포넌트 스타일 점검
